### PR TITLE
Mark received block response as ACK so caller does not process it again 

### DIFF
--- a/source/sn_coap_protocol.c
+++ b/source/sn_coap_protocol.c
@@ -1760,6 +1760,7 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
 
                 /* Get  */
                 stored_blockwise_msg_temp_ptr = search_sent_blockwise_message(handle, received_coap_msg_ptr->msg_id);
+                received_coap_msg_ptr->coap_status = COAP_STATUS_PARSER_BLOCKWISE_ACK;
 
                 if (stored_blockwise_msg_temp_ptr) {
                     /* Build response message */
@@ -1838,8 +1839,6 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
 
                     stored_blockwise_msg_temp_ptr->coap_msg_ptr->payload_len = original_payload_len;
                     stored_blockwise_msg_temp_ptr->coap_msg_ptr->payload_ptr = original_payload_ptr;
-
-                    received_coap_msg_ptr->coap_status = COAP_STATUS_PARSER_BLOCKWISE_ACK;
 
                     // Remove original message from the list when last block has been sent.
                     if (!((src_coap_blockwise_ack_msg_ptr->options_list_ptr->block1) & 0x08)) {

--- a/source/sn_coap_protocol.c
+++ b/source/sn_coap_protocol.c
@@ -85,7 +85,7 @@ static uint32_t              sn_coap_calculate_new_resend_time(const uint32_t cu
 static uint16_t              read_packet_msg_id(const coap_send_msg_s *stored_msg);
 static uint16_t              get_new_message_id(void);
 
-static bool                  compare_port(const sn_nsdl_addr_s* left, const sn_nsdl_addr_s* right);
+static bool                  compare_port(const sn_nsdl_addr_s *left, const sn_nsdl_addr_s *right);
 
 /* * * * * * * * * * * * * * * * * */
 /* * * * GLOBAL DECLARATIONS * * * */
@@ -258,7 +258,7 @@ int8_t sn_coap_protocol_set_duplicate_buffer_size(struct coap_s *handle, uint8_t
 }
 
 int8_t sn_coap_protocol_set_retransmission_parameters(struct coap_s *handle,
-        uint8_t resending_count, uint8_t resending_intervall)
+                                                      uint8_t resending_count, uint8_t resending_intervall)
 {
 #if ENABLE_RESENDINGS
     if (handle == NULL) {
@@ -280,14 +280,14 @@ int8_t sn_coap_protocol_set_retransmission_parameters(struct coap_s *handle,
 }
 
 int8_t sn_coap_protocol_set_retransmission_buffer(struct coap_s *handle,
-        uint8_t buffer_size_messages, uint16_t buffer_size_bytes)
+                                                  uint8_t buffer_size_messages, uint16_t buffer_size_bytes)
 {
 #if ENABLE_RESENDINGS
     if (handle == NULL) {
         return -1;
     }
     if (buffer_size_bytes <= SN_COAP_MAX_ALLOWED_RESENDING_BUFF_SIZE_BYTES &&
-        buffer_size_messages <= SN_COAP_MAX_ALLOWED_RESENDING_BUFF_SIZE_MSGS ) {
+            buffer_size_messages <= SN_COAP_MAX_ALLOWED_RESENDING_BUFF_SIZE_MSGS) {
         handle->sn_coap_resending_queue_bytes = buffer_size_bytes;
         handle->sn_coap_resending_queue_msgs = buffer_size_messages;
         return 0;
@@ -342,7 +342,7 @@ int8_t sn_coap_protocol_delete_retransmission_by_token(struct coap_s *handle, co
     }
 
     ns_list_foreach(coap_send_msg_s, stored_msg, &handle->linked_list_resent_msgs) {
-        uint8_t stored_token_len =  (stored_msg->send_msg_ptr.packet_ptr[0] & 0x0F);
+        uint8_t stored_token_len = (stored_msg->send_msg_ptr.packet_ptr[0] & 0x0F);
         if (stored_token_len == token_len) {
             if (memcmp(&stored_msg->send_msg_ptr.packet_ptr[4], token, stored_token_len) == 0) {
 
@@ -374,8 +374,8 @@ int8_t prepare_blockwise_message(struct coap_s *handle, sn_coap_hdr_s *src_coap_
 
 #if SN_COAP_BLOCKWISE_ENABLED || SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE /* If Message blockwising is not enabled, this part of code will not be compiled */
     if ((src_coap_msg_ptr->payload_len > SN_COAP_MAX_NONBLOCKWISE_PAYLOAD_SIZE) &&
-        (src_coap_msg_ptr->payload_len > handle->sn_coap_block_data_size) &&
-        (handle->sn_coap_block_data_size > 0)) {
+            (src_coap_msg_ptr->payload_len > handle->sn_coap_block_data_size) &&
+            (handle->sn_coap_block_data_size > 0)) {
         /* * * * Add Blockwise option to send CoAP message * * */
 
         /* Allocate memory for less used options */
@@ -438,8 +438,8 @@ int16_t sn_coap_protocol_build(struct coap_s *handle, sn_nsdl_addr_s *dst_addr_p
 #if SN_COAP_BLOCKWISE_ENABLED || SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE /* If Message blockwising is not enabled, this part of code will not be compiled */
     /* If blockwising needed */
     if ((src_coap_msg_ptr->payload_len > SN_COAP_MAX_NONBLOCKWISE_PAYLOAD_SIZE) &&
-        (src_coap_msg_ptr->payload_len > handle->sn_coap_block_data_size) &&
-        (handle->sn_coap_block_data_size > 0)) {
+            (src_coap_msg_ptr->payload_len > handle->sn_coap_block_data_size) &&
+            (handle->sn_coap_block_data_size > 0)) {
         /* Store original Payload length */
         original_payload_len = src_coap_msg_ptr->payload_len;
         /* Change Payload length of send message because Payload is blockwised */
@@ -464,8 +464,8 @@ int16_t sn_coap_protocol_build(struct coap_s *handle, sn_nsdl_addr_s *dst_addr_p
         /* Store message to Linked list for resending purposes */
         uint32_t resend_time = sn_coap_calculate_new_resend_time(handle->system_time, handle->sn_coap_resending_intervall, 0);
         if (sn_coap_protocol_linked_list_send_msg_store(handle, dst_addr_ptr, byte_count_built, dst_packet_data_ptr,
-                resend_time,
-                param) == 0) {
+                                                        resend_time,
+                                                        param) == 0) {
             return -4;
         }
     }
@@ -513,7 +513,7 @@ int16_t sn_coap_protocol_build(struct coap_s *handle, sn_nsdl_addr_s *dst_addr_p
 #if SN_COAP_BLOCKWISE_ENABLED || SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE
 static int16_t store_blockwise_copy(struct coap_s *handle, const sn_coap_hdr_s *src_coap_msg_ptr, void *param, uint16_t original_payload_len, bool copy_payload)
 {
-    coap_blockwise_msg_s * restrict stored_blockwise_msg_ptr;
+    coap_blockwise_msg_s *restrict stored_blockwise_msg_ptr;
 
     stored_blockwise_msg_ptr = sn_coap_protocol_calloc(handle, sizeof(coap_blockwise_msg_s));
     if (!stored_blockwise_msg_ptr) {
@@ -525,8 +525,8 @@ static int16_t store_blockwise_copy(struct coap_s *handle, const sn_coap_hdr_s *
     /* Fill struct */
     stored_blockwise_msg_ptr->timestamp = handle->system_time;
 
-    sn_coap_hdr_s * restrict copied_msg_ptr = sn_coap_protocol_copy_header(handle, src_coap_msg_ptr);
-    if( copied_msg_ptr == NULL ){
+    sn_coap_hdr_s *restrict copied_msg_ptr = sn_coap_protocol_copy_header(handle, src_coap_msg_ptr);
+    if (copied_msg_ptr == NULL) {
         handle->sn_coap_protocol_free(stored_blockwise_msg_ptr);
         tr_error("sn_coap_protocol_build - block header copy failed!");
         return -2;
@@ -555,18 +555,18 @@ static int16_t store_blockwise_copy(struct coap_s *handle, const sn_coap_hdr_s *
 }
 #endif
 
-sn_coap_hdr_s *sn_coap_protocol_parse(struct coap_s * restrict handle, sn_nsdl_addr_s * restrict src_addr_ptr, uint16_t packet_data_len, uint8_t * restrict packet_data_ptr, void *param)
+sn_coap_hdr_s *sn_coap_protocol_parse(struct coap_s *restrict handle, sn_nsdl_addr_s *restrict src_addr_ptr, uint16_t packet_data_len, uint8_t *restrict packet_data_ptr, void *param)
 {
     coap_version_e   coap_version              = COAP_VERSION_UNKNOWN;
 
     /* * * * Check given pointer * * * */
     if (src_addr_ptr == NULL || src_addr_ptr->addr_ptr == NULL ||
-        packet_data_ptr == NULL || handle == NULL) {
+            packet_data_ptr == NULL || handle == NULL) {
         return NULL;
     }
 
     /* * * * Parse Packet data to CoAP message by using CoAP Header parser * * * */
-    sn_coap_hdr_s * restrict returned_dst_coap_msg_ptr = sn_coap_parser(handle, packet_data_len, packet_data_ptr, &coap_version);
+    sn_coap_hdr_s *restrict returned_dst_coap_msg_ptr = sn_coap_parser(handle, packet_data_len, packet_data_ptr, &coap_version);
 
     /* Check status of returned pointer */
     if (returned_dst_coap_msg_ptr == NULL) {
@@ -641,12 +641,12 @@ sn_coap_hdr_s *sn_coap_protocol_parse(struct coap_s * restrict handle, sn_nsdl_a
 
     // If no message duplication detected
     if ((returned_dst_coap_msg_ptr->msg_type == COAP_MSG_TYPE_CONFIRMABLE ||
-         returned_dst_coap_msg_ptr->msg_type == COAP_MSG_TYPE_NON_CONFIRMABLE ||
-         (returned_dst_coap_msg_ptr->msg_type == COAP_MSG_TYPE_ACKNOWLEDGEMENT &&
-          returned_dst_coap_msg_ptr->msg_code != COAP_MSG_CODE_EMPTY)) &&
-          handle->sn_coap_duplication_buffer_size != 0) {
+            returned_dst_coap_msg_ptr->msg_type == COAP_MSG_TYPE_NON_CONFIRMABLE ||
+            (returned_dst_coap_msg_ptr->msg_type == COAP_MSG_TYPE_ACKNOWLEDGEMENT &&
+             returned_dst_coap_msg_ptr->msg_code != COAP_MSG_CODE_EMPTY)) &&
+            handle->sn_coap_duplication_buffer_size != 0) {
 
-        coap_duplication_info_s* response = sn_coap_protocol_linked_list_duplication_info_search(handle,
+        coap_duplication_info_s *response = sn_coap_protocol_linked_list_duplication_info_search(handle,
                                                                                                  src_addr_ptr,
                                                                                                  returned_dst_coap_msg_ptr->msg_id);
         if (response == NULL) {
@@ -681,7 +681,7 @@ sn_coap_hdr_s *sn_coap_protocol_parse(struct coap_s * restrict handle, sn_nsdl_a
                 if (response->packet_ptr) {
                     tr_debug("sn_coap_protocol_parse - send ack for duplicate message");
                     handle->sn_coap_tx_callback(response->packet_ptr,
-                            response->packet_len, response->address, response->param);
+                                                response->packet_len, response->address, response->param);
                 } else {
                     tr_error("sn_coap_protocol_parse - response not yet build");
                 }
@@ -699,8 +699,8 @@ sn_coap_hdr_s *sn_coap_protocol_parse(struct coap_s * restrict handle, sn_nsdl_a
 #if SN_COAP_BLOCKWISE_ENABLED || SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE
 
     if (returned_dst_coap_msg_ptr->options_list_ptr != NULL &&
-        (returned_dst_coap_msg_ptr->options_list_ptr->block1 != COAP_OPTION_BLOCK_NONE ||
-        returned_dst_coap_msg_ptr->options_list_ptr->block2 != COAP_OPTION_BLOCK_NONE)) {
+            (returned_dst_coap_msg_ptr->options_list_ptr->block1 != COAP_OPTION_BLOCK_NONE ||
+             returned_dst_coap_msg_ptr->options_list_ptr->block2 != COAP_OPTION_BLOCK_NONE)) {
 
         // the sn_coap_handle_blockwise_message() will return the given message on success or NULL on error
         if (sn_coap_handle_blockwise_message(handle, src_addr_ptr, returned_dst_coap_msg_ptr, param) == NULL) {
@@ -790,8 +790,8 @@ cleanup:
         bool remove_from_the_list = false;
         if (stored_blockwise_msg_temp_ptr) {
             if (stored_blockwise_msg_temp_ptr->coap_msg_ptr &&
-                stored_blockwise_msg_temp_ptr->coap_msg_ptr->options_list_ptr &&
-                stored_blockwise_msg_temp_ptr->coap_msg_ptr->options_list_ptr->observe != COAP_OBSERVE_NONE) {
+                    stored_blockwise_msg_temp_ptr->coap_msg_ptr->options_list_ptr &&
+                    stored_blockwise_msg_temp_ptr->coap_msg_ptr->options_list_ptr->observe != COAP_OBSERVE_NONE) {
                 remove_from_the_list = false;
             } else {
                 remove_from_the_list = true;
@@ -834,8 +834,8 @@ cleanup:
 
 int8_t sn_coap_protocol_exec(struct coap_s *handle, uint32_t current_time)
 {
-    if( !handle ){
-       return -1;
+    if (!handle) {
+        return -1;
     }
 
     /* * * * Store current System time * * * */
@@ -890,7 +890,7 @@ rescan:
             } else {
                 /* Send message  */
                 handle->sn_coap_tx_callback(stored_msg_ptr->send_msg_ptr.packet_ptr,
-                        stored_msg_ptr->send_msg_ptr.packet_len, &stored_msg_ptr->send_msg_ptr.dst_addr_ptr, stored_msg_ptr->param);
+                                            stored_msg_ptr->send_msg_ptr.packet_len, &stored_msg_ptr->send_msg_ptr.dst_addr_ptr, stored_msg_ptr->param);
 
                 /* * * Count new Resending time  * * */
                 stored_msg_ptr->resending_time = sn_coap_calculate_new_resend_time(current_time,
@@ -928,11 +928,11 @@ rescan:
  * \return 1 Msg stored properly
  *****************************************************************************/
 
-static uint8_t sn_coap_protocol_linked_list_send_msg_store(struct coap_s * restrict handle, sn_nsdl_addr_s * restrict dst_addr_ptr, uint_fast16_t send_packet_data_len,
-        uint8_t * restrict send_packet_data_ptr, uint32_t sending_time, void *param)
+static uint8_t sn_coap_protocol_linked_list_send_msg_store(struct coap_s *restrict handle, sn_nsdl_addr_s *restrict dst_addr_ptr, uint_fast16_t send_packet_data_len,
+                                                           uint8_t *restrict send_packet_data_ptr, uint32_t sending_time, void *param)
 {
 
-    coap_send_msg_s * restrict stored_msg_ptr;
+    coap_send_msg_s *restrict stored_msg_ptr;
 
     /* If both queue parameters are "0" or resending count is "0", then re-sending is disabled */
     if (((handle->sn_coap_resending_queue_msgs == 0) && (handle->sn_coap_resending_queue_bytes == 0)) || (handle->sn_coap_resending_count == 0)) {
@@ -995,7 +995,7 @@ static uint8_t sn_coap_protocol_linked_list_send_msg_store(struct coap_s * restr
  * \param msg_id is searching key for removed message
  *****************************************************************************/
 
-static void sn_coap_protocol_linked_list_send_msg_remove(struct coap_s * restrict handle, const sn_nsdl_addr_s * restrict src_addr_ptr, uint16_t msg_id)
+static void sn_coap_protocol_linked_list_send_msg_remove(struct coap_s *restrict handle, const sn_nsdl_addr_s *restrict src_addr_ptr, uint16_t msg_id)
 {
     /* Loop all stored resending messages in Linked list */
     ns_list_foreach(coap_send_msg_s, stored_msg_ptr, &handle->linked_list_resent_msgs) {
@@ -1065,10 +1065,10 @@ uint16_t sn_coap_protocol_get_configured_blockwise_size(struct coap_s *handle)
  * \param *addr_ptr is pointer to Address information to be stored
  *****************************************************************************/
 
-static void sn_coap_protocol_linked_list_duplication_info_store(struct coap_s * restrict handle, sn_nsdl_addr_s * restrict addr_ptr,
-        uint16_t msg_id, void *param)
+static void sn_coap_protocol_linked_list_duplication_info_store(struct coap_s *restrict handle, sn_nsdl_addr_s *restrict addr_ptr,
+                                                                uint16_t msg_id, void *param)
 {
-    coap_duplication_info_s * restrict stored_duplication_info_ptr = NULL;
+    coap_duplication_info_s *restrict stored_duplication_info_ptr = NULL;
 
     /* * * * Allocating memory for stored Duplication info * * * */
 
@@ -1121,8 +1121,8 @@ static void sn_coap_protocol_linked_list_duplication_info_store(struct coap_s * 
  * \return Return value is 0 when message found and -1 if not found
  *****************************************************************************/
 
-static coap_duplication_info_s* sn_coap_protocol_linked_list_duplication_info_search(const struct coap_s *handle,
-        const sn_nsdl_addr_s *addr_ptr, const uint16_t msg_id)
+static coap_duplication_info_s *sn_coap_protocol_linked_list_duplication_info_search(const struct coap_s *handle,
+                                                                                     const sn_nsdl_addr_s *addr_ptr, const uint16_t msg_id)
 {
     /* Loop all nodes in Linked list for searching Message ID */
     ns_list_foreach(coap_duplication_info_s, stored_duplication_info_ptr, &handle->linked_list_duplication_msgs) {
@@ -1247,14 +1247,14 @@ static void sn_coap_protocol_linked_list_blockwise_msg_remove(struct coap_s *han
  * \param size1 Size of the whole incoming message
  *****************************************************************************/
 
-static void sn_coap_protocol_linked_list_blockwise_payload_store(struct coap_s * restrict handle, sn_nsdl_addr_s * restrict addr_ptr,
-        uint16_t payload_len,
-        uint8_t * restrict payload_ptr,
-        uint8_t * restrict token_ptr,
-        uint8_t token_len,
-        uint32_t block_number,
-        uint16_t block_size,
-        uint32_t size1)
+static void sn_coap_protocol_linked_list_blockwise_payload_store(struct coap_s *restrict handle, sn_nsdl_addr_s *restrict addr_ptr,
+                                                                 uint16_t payload_len,
+                                                                 uint8_t *restrict payload_ptr,
+                                                                 uint8_t *restrict token_ptr,
+                                                                 uint8_t token_len,
+                                                                 uint32_t block_number,
+                                                                 uint16_t block_size,
+                                                                 uint32_t size1)
 {
     if (!addr_ptr || !payload_len || !payload_ptr) {
         return;
@@ -1262,14 +1262,14 @@ static void sn_coap_protocol_linked_list_blockwise_payload_store(struct coap_s *
 
     // Do not add duplicates to list, this could happen if server needs to retransmit block message again
     if (sn_coap_protocol_linked_list_blockwise_payload_search_compare_block_number(handle,
-                                                                             addr_ptr,
-                                                                             token_ptr,
-                                                                             token_len,
-                                                                             block_number)) {
+                                                                                   addr_ptr,
+                                                                                   token_ptr,
+                                                                                   token_len,
+                                                                                   block_number)) {
         return;
     }
 
-    coap_blockwise_payload_s * restrict stored_blockwise_payload_ptr = sn_coap_protocol_linked_list_blockwise_search(handle, addr_ptr, token_ptr, token_len);
+    coap_blockwise_payload_s *restrict stored_blockwise_payload_ptr = sn_coap_protocol_linked_list_blockwise_search(handle, addr_ptr, token_ptr, token_len);
 
     if (stored_blockwise_payload_ptr && stored_blockwise_payload_ptr->use_size1) {
         memcpy(stored_blockwise_payload_ptr->payload_ptr + (block_number * block_size), payload_ptr, payload_len);
@@ -1277,7 +1277,7 @@ static void sn_coap_protocol_linked_list_blockwise_payload_store(struct coap_s *
         uint16_t new_len = stored_blockwise_payload_ptr->payload_len + payload_len;
         tr_debug("sn_coap_protocol_linked_list_blockwise_payload_store - reallocate from %d to %d", stored_blockwise_payload_ptr->payload_len, new_len);
 
-        uint8_t * restrict temp_ptr = handle->sn_coap_protocol_malloc(stored_blockwise_payload_ptr->payload_len);
+        uint8_t *restrict temp_ptr = handle->sn_coap_protocol_malloc(stored_blockwise_payload_ptr->payload_len);
         if (temp_ptr == NULL) {
             tr_error("sn_coap_protocol_linked_list_blockwise_payload_store - failed to allocate temp buffer!");
             sn_coap_protocol_linked_list_blockwise_payload_remove(handle, stored_blockwise_payload_ptr);
@@ -1438,10 +1438,10 @@ static coap_blockwise_payload_s *sn_coap_protocol_linked_list_blockwise_search(s
 }
 
 static bool sn_coap_protocol_linked_list_blockwise_payload_search_compare_block_number(struct coap_s *handle,
-                                                                                   const sn_nsdl_addr_s *src_addr_ptr,
-                                                                                   const uint8_t *token_ptr,
-                                                                                   uint8_t token_len,
-                                                                                   uint32_t block_number)
+                                                                                       const sn_nsdl_addr_s *src_addr_ptr,
+                                                                                       const uint8_t *token_ptr,
+                                                                                       uint8_t token_len,
+                                                                                       uint32_t block_number)
 {
     /* Loop all stored blockwise payloads in Linked list */
     ns_list_foreach(coap_blockwise_payload_s, stored_payload_info_ptr, &handle->linked_list_blockwise_received_payloads) {
@@ -1505,7 +1505,7 @@ static uint32_t sn_coap_protocol_linked_list_blockwise_payloads_get_len(struct c
         if ((0 == memcmp(src_addr_ptr->addr_ptr, searched_payload_info_ptr->addr_ptr, src_addr_ptr->addr_len)) && (searched_payload_info_ptr->port == src_addr_ptr->port)) {
             /* Check token */
             if (token_ptr) {
-                if(!searched_payload_info_ptr->token_ptr || (token_len != searched_payload_info_ptr->token_len) || (memcmp(searched_payload_info_ptr->token_ptr, token_ptr, token_len))) {
+                if (!searched_payload_info_ptr->token_ptr || (token_len != searched_payload_info_ptr->token_len) || (memcmp(searched_payload_info_ptr->token_ptr, token_ptr, token_len))) {
                     continue;
                 }
             } else if (searched_payload_info_ptr->token_ptr) {
@@ -1540,7 +1540,7 @@ rescan:
             ns_list_remove(&handle->linked_list_blockwise_sent_msgs, removed_blocwise_msg_ptr);
 
             /* * * * This messages has timed out, remove it from Linked list * * * */
-            if( removed_blocwise_msg_ptr->coap_msg_ptr ){
+            if (removed_blocwise_msg_ptr->coap_msg_ptr) {
                 if (handle->sn_coap_rx_callback) {
                     /* Notify the application about the time out */
                     removed_blocwise_msg_ptr->coap_msg_ptr->coap_status = COAP_STATUS_BUILDER_BLOCK_SENDING_FAILED;
@@ -1603,7 +1603,7 @@ coap_send_msg_s *sn_coap_protocol_allocate_mem_for_msg(struct coap_s *handle, sn
     msg_ptr->send_msg_ptr.dst_addr_ptr.addr_ptr = sn_coap_protocol_calloc(handle, dst_addr_ptr->addr_len);
 
     if ((msg_ptr->send_msg_ptr.dst_addr_ptr.addr_ptr == NULL) ||
-        (msg_ptr->send_msg_ptr.packet_ptr == NULL)) {
+            (msg_ptr->send_msg_ptr.packet_ptr == NULL)) {
 
         sn_coap_protocol_release_allocated_send_msg_mem(handle, msg_ptr);
         return 0;
@@ -1655,7 +1655,7 @@ static uint_fast16_t sn_coap_count_linked_list_size(const coap_send_msg_list_t *
 
 #if SN_COAP_BLOCKWISE_ENABLED || SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE
 
-static coap_blockwise_msg_s* search_sent_blockwise_message(struct coap_s *handle, uint16_t msg_id)
+static coap_blockwise_msg_s *search_sent_blockwise_message(struct coap_s *handle, uint16_t msg_id)
 {
     ns_list_foreach(coap_blockwise_msg_s, tmp, &handle->linked_list_blockwise_sent_msgs) {
         if (tmp->coap_msg_ptr && tmp->coap_msg_ptr->msg_id == msg_id) {
@@ -1701,12 +1701,11 @@ void sn_coap_protocol_block_remove(struct coap_s *handle, sn_nsdl_addr_s *source
         }
 
         /* Check the payload */
-        if(payload_length != stored_payload_info_ptr->payload_len){
+        if (payload_length != stored_payload_info_ptr->payload_len) {
             continue;
         }
 
-        if(!memcmp(stored_payload_info_ptr->payload_ptr, payload, stored_payload_info_ptr->payload_len))
-        {
+        if (!memcmp(stored_payload_info_ptr->payload_ptr, payload, stored_payload_info_ptr->payload_len)) {
             /* Everything matches, remove and return. */
             sn_coap_protocol_linked_list_blockwise_payload_remove(handle, stored_payload_info_ptr);
             return;
@@ -1748,7 +1747,7 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
 {
     sn_coap_hdr_s *src_coap_blockwise_ack_msg_ptr = NULL;
     uint16_t dst_packed_data_needed_mem = 0;
-    uint8_t * restrict dst_ack_packet_data_ptr = NULL;
+    uint8_t *restrict dst_ack_packet_data_ptr = NULL;
     uint8_t block_temp = 0;
 
     uint16_t original_payload_len = 0;
@@ -1830,9 +1829,9 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                     uint32_t resend_time = sn_coap_calculate_new_resend_time(handle->system_time, handle->sn_coap_resending_intervall, 0);
                     if (src_coap_blockwise_ack_msg_ptr->msg_type == COAP_MSG_TYPE_CONFIRMABLE) {
                         sn_coap_protocol_linked_list_send_msg_store(handle, src_addr_ptr,
-                                dst_packed_data_needed_mem,
-                                dst_ack_packet_data_ptr,
-                                resend_time, param);
+                                                                    dst_packed_data_needed_mem,
+                                                                    dst_ack_packet_data_ptr,
+                                                                    resend_time, param);
                     }
 #endif
 
@@ -1866,11 +1865,11 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
             bool blocks_in_order = true;
 
             if (block_number > 0 &&
-                !sn_coap_protocol_linked_list_blockwise_payload_search_compare_block_number(handle,
-                                                                                     src_addr_ptr,
-                                                                                     received_coap_msg_ptr->token_ptr,
-                                                                                     received_coap_msg_ptr->token_len,
-                                                                                     block_number - 1)) {
+                    !sn_coap_protocol_linked_list_blockwise_payload_search_compare_block_number(handle,
+                                                                                                src_addr_ptr,
+                                                                                                received_coap_msg_ptr->token_ptr,
+                                                                                                received_coap_msg_ptr->token_len,
+                                                                                                block_number - 1)) {
                 blocks_in_order = false;
             }
 
@@ -1902,8 +1901,7 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                     // Include maximum size that stack can handle into response
                     tr_info("sn_coap_handle_blockwise_message - (recv block1) entity too large");
                     src_coap_blockwise_ack_msg_ptr->msg_code = COAP_MSG_CODE_RESPONSE_REQUEST_ENTITY_TOO_LARGE;
-                }
-                else {
+                } else {
                     src_coap_blockwise_ack_msg_ptr->options_list_ptr->block1 = received_coap_msg_ptr->options_list_ptr->block1;
                     src_coap_blockwise_ack_msg_ptr->msg_type = COAP_MSG_TYPE_ACKNOWLEDGEMENT;
 
@@ -1912,10 +1910,10 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                     uint_fast16_t block_size = 16u << block_temp;
 
                     if (block_size >  handle->sn_coap_block_data_size) {
-                         // Include maximum size that stack can handle into response
+                        // Include maximum size that stack can handle into response
                         tr_info("sn_coap_handle_blockwise_message - (recv block1) entity too large");
-                         src_coap_blockwise_ack_msg_ptr->msg_code = COAP_MSG_CODE_RESPONSE_REQUEST_ENTITY_TOO_LARGE;
-                         src_coap_blockwise_ack_msg_ptr->options_list_ptr->size1 = handle->sn_coap_block_data_size;
+                        src_coap_blockwise_ack_msg_ptr->msg_code = COAP_MSG_CODE_RESPONSE_REQUEST_ENTITY_TOO_LARGE;
+                        src_coap_blockwise_ack_msg_ptr->options_list_ptr->size1 = handle->sn_coap_block_data_size;
                     }
 
                     if (block_temp > sn_coap_convert_block_size(handle->sn_coap_block_data_size)) {
@@ -1958,7 +1956,7 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
 #endif
                 // Store only in success case
                 if (src_coap_blockwise_ack_msg_ptr->msg_code != COAP_MSG_CODE_RESPONSE_REQUEST_ENTITY_INCOMPLETE &&
-                    src_coap_blockwise_ack_msg_ptr->msg_code != COAP_MSG_CODE_RESPONSE_REQUEST_ENTITY_TOO_LARGE) {
+                        src_coap_blockwise_ack_msg_ptr->msg_code != COAP_MSG_CODE_RESPONSE_REQUEST_ENTITY_TOO_LARGE) {
                     uint16_t block_size = 1u << ((received_coap_msg_ptr->options_list_ptr->block1 & 0x07) + 4);
                     sn_coap_protocol_linked_list_blockwise_payload_store(handle,
                                                                          src_addr_ptr,
@@ -2126,9 +2124,9 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
 #if ENABLE_RESENDINGS
                     uint32_t resend_time = sn_coap_calculate_new_resend_time(handle->system_time, handle->sn_coap_resending_intervall, 0);
                     sn_coap_protocol_linked_list_send_msg_store(handle, src_addr_ptr,
-                            dst_packed_data_needed_mem,
-                            dst_ack_packet_data_ptr,
-                            resend_time, param);
+                                                                dst_packed_data_needed_mem,
+                                                                dst_ack_packet_data_ptr,
+                                                                resend_time, param);
 #endif
                     handle->sn_coap_protocol_free(dst_ack_packet_data_ptr);
                     dst_ack_packet_data_ptr = 0;
@@ -2210,7 +2208,7 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                  * This is needed only in case of notification message.
                 */
                 if (src_coap_blockwise_ack_msg_ptr->options_list_ptr &&
-                    src_coap_blockwise_ack_msg_ptr->options_list_ptr->observe != COAP_OBSERVE_NONE) {
+                        src_coap_blockwise_ack_msg_ptr->options_list_ptr->observe != COAP_OBSERVE_NONE) {
                     if (src_coap_blockwise_ack_msg_ptr->token_ptr) {
                         handle->sn_coap_protocol_free(src_coap_blockwise_ack_msg_ptr->token_ptr);
                         if (received_coap_msg_ptr->token_len) {
@@ -2218,8 +2216,7 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                             if (src_coap_blockwise_ack_msg_ptr->token_ptr) {
                                 src_coap_blockwise_ack_msg_ptr->token_len = received_coap_msg_ptr->token_len;
                             }
-                        }
-                        else {
+                        } else {
                             src_coap_blockwise_ack_msg_ptr->token_ptr = NULL;
                             src_coap_blockwise_ack_msg_ptr->token_len = 0;
                         }
@@ -2316,9 +2313,9 @@ int8_t sn_coap_convert_block_size(uint16_t block_size)
     return -1;
 }
 
-static sn_coap_hdr_s *sn_coap_protocol_copy_header(struct coap_s * restrict handle, const sn_coap_hdr_s * restrict source_header_ptr)
+static sn_coap_hdr_s *sn_coap_protocol_copy_header(struct coap_s *restrict handle, const sn_coap_hdr_s *restrict source_header_ptr)
 {
-    sn_coap_hdr_s * restrict destination_header_ptr;
+    sn_coap_hdr_s *restrict destination_header_ptr;
 
     destination_header_ptr = sn_coap_parser_alloc_message(handle);
     if (!destination_header_ptr) {
@@ -2361,8 +2358,8 @@ static sn_coap_hdr_s *sn_coap_protocol_copy_header(struct coap_s * restrict hand
             return 0;
         }
 
-        const sn_coap_options_list_s * restrict source_options_list_ptr = source_header_ptr->options_list_ptr;
-        sn_coap_options_list_s * restrict destination_options_list_ptr = destination_header_ptr->options_list_ptr;
+        const sn_coap_options_list_s *restrict source_options_list_ptr = source_header_ptr->options_list_ptr;
+        sn_coap_options_list_s *restrict destination_options_list_ptr = destination_header_ptr->options_list_ptr;
 
         destination_options_list_ptr->max_age = source_options_list_ptr->max_age;
 
@@ -2447,7 +2444,7 @@ static bool sn_coap_protocol_update_duplicate_package_data(const struct coap_s *
                                                            const uint8_t *dst_packet_data_ptr)
 {
     if (coap_msg_ptr->msg_type == COAP_MSG_TYPE_ACKNOWLEDGEMENT &&
-        handle->sn_coap_duplication_buffer_size != 0) {
+            handle->sn_coap_duplication_buffer_size != 0) {
         return sn_coap_protocol_update_duplicate_package_data_all(handle, dst_addr_ptr, coap_msg_ptr, data_size, dst_packet_data_ptr);
     }
     return true;
@@ -2459,7 +2456,7 @@ static bool sn_coap_protocol_update_duplicate_package_data_all(const struct coap
                                                                const int_fast16_t data_size,
                                                                const uint8_t *dst_packet_data_ptr)
 {
-    coap_duplication_info_s* info = sn_coap_protocol_linked_list_duplication_info_search(handle,
+    coap_duplication_info_s *info = sn_coap_protocol_linked_list_duplication_info_search(handle,
                                                                                          dst_addr_ptr,
                                                                                          coap_msg_ptr->msg_id);
 
@@ -2504,7 +2501,7 @@ void *sn_coap_protocol_calloc(struct coap_s *handle, uint_fast16_t length)
     return result;
 }
 
-static bool compare_port(const sn_nsdl_addr_s* left, const sn_nsdl_addr_s* right)
+static bool compare_port(const sn_nsdl_addr_s *left, const sn_nsdl_addr_s *right)
 {
     bool match = false;
     if (left->port == right->port) {

--- a/source/sn_coap_protocol.c
+++ b/source/sn_coap_protocol.c
@@ -641,9 +641,7 @@ sn_coap_hdr_s *sn_coap_protocol_parse(struct coap_s *restrict handle, sn_nsdl_ad
 
     // If no message duplication detected
     if ((returned_dst_coap_msg_ptr->msg_type == COAP_MSG_TYPE_CONFIRMABLE ||
-            returned_dst_coap_msg_ptr->msg_type == COAP_MSG_TYPE_NON_CONFIRMABLE ||
-            (returned_dst_coap_msg_ptr->msg_type == COAP_MSG_TYPE_ACKNOWLEDGEMENT &&
-             returned_dst_coap_msg_ptr->msg_code != COAP_MSG_CODE_EMPTY)) &&
+            returned_dst_coap_msg_ptr->msg_type == COAP_MSG_TYPE_NON_CONFIRMABLE) &&
             handle->sn_coap_duplication_buffer_size != 0) {
 
         coap_duplication_info_s *response = sn_coap_protocol_linked_list_duplication_info_search(handle,
@@ -676,7 +674,7 @@ sn_coap_hdr_s *sn_coap_protocol_parse(struct coap_s *restrict handle, sn_nsdl_ad
             returned_dst_coap_msg_ptr->coap_status = COAP_STATUS_PARSER_DUPLICATED_MSG;
 
             // Send ACK response
-            if (response && returned_dst_coap_msg_ptr->msg_type != COAP_MSG_TYPE_ACKNOWLEDGEMENT) {
+            if (response) {
                 // Check that response has been created
                 if (response->packet_ptr) {
                     tr_debug("sn_coap_protocol_parse - send ack for duplicate message");

--- a/test/mbed-coap/unittest/sn_coap_protocol/libCoap_protocol_test.cpp
+++ b/test/mbed-coap/unittest/sn_coap_protocol/libCoap_protocol_test.cpp
@@ -28,8 +28,8 @@
 
 int retCounter = 0;
 static coap_s *coap_handle = NULL;
-void myFree(void* addr);
-void* myMalloc(uint16_t size);
+void myFree(void *addr);
+void *myMalloc(uint16_t size);
 uint8_t null_tx_cb(uint8_t *a, uint16_t b, sn_nsdl_addr_s *c, void *d);
 void test_block1_receive(struct coap_s *handle, sn_nsdl_addr_s *src_addr_ptr, uint16_t packet_data_len, uint8_t *packet_data_ptr);
 void test_block1_send(struct coap_s *handle, sn_nsdl_addr_s *src_addr_ptr, uint16_t packet_data_len, uint8_t *packet_data_ptr);
@@ -49,19 +49,20 @@ TEST_GROUP(libCoap_protocol)
     }
 };
 
-void* myMalloc(uint16_t size)
+void *myMalloc(uint16_t size)
 {
-    if( retCounter > 0 ){
+    if (retCounter > 0) {
         int a = retCounter;
         retCounter--;
         return malloc(size);
-    }else {
+    } else {
         return NULL;
     }
 }
 
-void myFree(void* addr){
-    if( addr ){
+void myFree(void *addr)
+{
+    if (addr) {
         free(addr);
     }
 }
@@ -78,12 +79,12 @@ int8_t null_rx_cb(sn_coap_hdr_s *a, sn_nsdl_addr_s *b, void *c)
 
 TEST(libCoap_protocol, sn_coap_protocol_destroy)
 {
-    CHECK( -1 == sn_coap_protocol_destroy(NULL));
+    CHECK(-1 == sn_coap_protocol_destroy(NULL));
     struct coap_s *handle = (struct coap_s *)malloc(sizeof(struct coap_s));
     handle->sn_coap_protocol_free = &myFree;
     handle->sn_coap_protocol_malloc = &myMalloc;
     ns_list_init(&handle->linked_list_resent_msgs);
-    coap_send_msg_s *msg_ptr = (coap_send_msg_s*)malloc(sizeof(coap_send_msg_s));
+    coap_send_msg_s *msg_ptr = (coap_send_msg_s *)malloc(sizeof(coap_send_msg_s));
     memset(msg_ptr, 0, sizeof(coap_send_msg_s));
 
     ns_list_add_to_end(&handle->linked_list_resent_msgs, msg_ptr);
@@ -94,7 +95,7 @@ TEST(libCoap_protocol, sn_coap_protocol_destroy)
     ns_list_init(&handle->linked_list_blockwise_sent_msgs);
     ns_list_init(&handle->linked_list_blockwise_received_payloads);
 #endif
-    CHECK( 0 == sn_coap_protocol_destroy(handle));
+    CHECK(0 == sn_coap_protocol_destroy(handle));
 }
 
 TEST(libCoap_protocol, sn_coap_protocol_init_null_func_ptrs)
@@ -107,7 +108,7 @@ TEST(libCoap_protocol, sn_coap_protocol_init_null_malloc)
     POINTERS_EQUAL(NULL, sn_coap_protocol_init(myMalloc, myFree, null_tx_cb, NULL));
 
     retCounter = 1;
-    struct coap_s * handle = sn_coap_protocol_init(myMalloc, myFree, null_tx_cb, NULL);
+    struct coap_s *handle = sn_coap_protocol_init(myMalloc, myFree, null_tx_cb, NULL);
     CHECK(NULL != handle);
 
     sn_coap_protocol_destroy(handle);
@@ -116,10 +117,10 @@ TEST(libCoap_protocol, sn_coap_protocol_init_null_malloc)
 TEST(libCoap_protocol, sn_coap_protocol_set_block_size)
 {
 #if SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE
-    CHECK( 0 == sn_coap_protocol_set_block_size(coap_handle,16) );
-    CHECK( -1 == sn_coap_protocol_set_block_size(NULL,1) );
+    CHECK(0 == sn_coap_protocol_set_block_size(coap_handle, 16));
+    CHECK(-1 == sn_coap_protocol_set_block_size(NULL, 1));
 #endif
-    CHECK( -1 == sn_coap_protocol_set_block_size(coap_handle,1) );
+    CHECK(-1 == sn_coap_protocol_set_block_size(coap_handle, 1));
 }
 
 TEST(libCoap_protocol, sn_coap_protocol_clear_sent_blockwise_messages)
@@ -127,44 +128,44 @@ TEST(libCoap_protocol, sn_coap_protocol_clear_sent_blockwise_messages)
 #if SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE
     sn_coap_protocol_clear_sent_blockwise_messages(NULL);
 
-    coap_blockwise_msg_s *message = (coap_blockwise_msg_s*)malloc(sizeof(coap_blockwise_msg_s));
+    coap_blockwise_msg_s *message = (coap_blockwise_msg_s *)malloc(sizeof(coap_blockwise_msg_s));
     memset(message, 0, sizeof(coap_blockwise_msg_s));
-    message->coap_msg_ptr = (sn_coap_hdr_s*)malloc(sizeof(sn_coap_hdr_s));
+    message->coap_msg_ptr = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
     memset(message->coap_msg_ptr, 0, sizeof(sn_coap_hdr_s));
-    message->coap_msg_ptr->payload_ptr = (uint8_t*)malloc(5);
+    message->coap_msg_ptr->payload_ptr = (uint8_t *)malloc(5);
     message->coap_msg_ptr->payload_len = 5;
     ns_list_add_to_end(&coap_handle->linked_list_blockwise_sent_msgs, message);
     sn_coap_protocol_clear_sent_blockwise_messages(coap_handle);
-    CHECK( 0 == ns_list_count(&coap_handle->linked_list_blockwise_sent_msgs) );
+    CHECK(0 == ns_list_count(&coap_handle->linked_list_blockwise_sent_msgs));
 #endif
 }
 
 TEST(libCoap_protocol, sn_coap_protocol_set_duplicate_buffer_size)
 {
 #if SN_COAP_DUPLICATION_MAX_MSGS_COUNT
-    CHECK( 0 == sn_coap_protocol_set_duplicate_buffer_size(coap_handle,3));
-    CHECK( -1 == sn_coap_protocol_set_duplicate_buffer_size(NULL,3));
+    CHECK(0 == sn_coap_protocol_set_duplicate_buffer_size(coap_handle, 3));
+    CHECK(-1 == sn_coap_protocol_set_duplicate_buffer_size(NULL, 3));
 #endif
-    CHECK( -1 == sn_coap_protocol_set_duplicate_buffer_size(coap_handle,999));
+    CHECK(-1 == sn_coap_protocol_set_duplicate_buffer_size(coap_handle, 999));
 }
 
 TEST(libCoap_protocol, sn_coap_protocol_set_retransmission_parameters)
 {
 #if ENABLE_RESENDINGS
-    CHECK( 0 == sn_coap_protocol_set_retransmission_parameters(coap_handle,3,0) );
-    CHECK( 0 == sn_coap_protocol_set_retransmission_parameters(coap_handle,3, 10) );
-    CHECK( -1 == sn_coap_protocol_set_retransmission_parameters(NULL,3,0) );
+    CHECK(0 == sn_coap_protocol_set_retransmission_parameters(coap_handle, 3, 0));
+    CHECK(0 == sn_coap_protocol_set_retransmission_parameters(coap_handle, 3, 10));
+    CHECK(-1 == sn_coap_protocol_set_retransmission_parameters(NULL, 3, 0));
 #endif
-    CHECK( -1 == sn_coap_protocol_set_retransmission_parameters(coap_handle,999,0) );
+    CHECK(-1 == sn_coap_protocol_set_retransmission_parameters(coap_handle, 999, 0));
 }
 
 TEST(libCoap_protocol, sn_coap_protocol_set_retransmission_buffer)
 {
 #if ENABLE_RESENDINGS
-    CHECK( 0 == sn_coap_protocol_set_retransmission_buffer(coap_handle,3,3) );
-    CHECK( -1 == sn_coap_protocol_set_retransmission_buffer(NULL,3,3) );
+    CHECK(0 == sn_coap_protocol_set_retransmission_buffer(coap_handle, 3, 3));
+    CHECK(-1 == sn_coap_protocol_set_retransmission_buffer(NULL, 3, 3));
 #endif
-    CHECK( -1 == sn_coap_protocol_set_retransmission_buffer(coap_handle,3,999) );
+    CHECK(-1 == sn_coap_protocol_set_retransmission_buffer(coap_handle, 3, 999));
 }
 
 //TEST(libCoap_protocol, sn_coap_protocol_clear_retransmission_buffer)
@@ -189,17 +190,17 @@ TEST(libCoap_protocol, sn_coap_protocol_delete_retransmission)
     dst_addr_ptr.addr_len = 4;
     dst_addr_ptr.type = SN_NSDL_ADDRESS_TYPE_IPV4;
 
-    struct coap_s * handle = sn_coap_protocol_init(myMalloc, myFree, null_tx_cb, NULL);
+    struct coap_s *handle = sn_coap_protocol_init(myMalloc, myFree, null_tx_cb, NULL);
 
-    CHECK( -1 == sn_coap_protocol_delete_retransmission(NULL, 0));
+    CHECK(-1 == sn_coap_protocol_delete_retransmission(NULL, 0));
 
-    CHECK( -2 == sn_coap_protocol_delete_retransmission(handle, 0));
+    CHECK(-2 == sn_coap_protocol_delete_retransmission(handle, 0));
 
     sn_coap_builder_stub.expectedInt16 = 4;
 
-    CHECK( 0 < sn_coap_protocol_build(handle, &dst_addr_ptr, dst_packet_data_ptr, &src_coap_msg_ptr, NULL));
+    CHECK(0 < sn_coap_protocol_build(handle, &dst_addr_ptr, dst_packet_data_ptr, &src_coap_msg_ptr, NULL));
 
-    CHECK( 0 == sn_coap_protocol_delete_retransmission(handle, 99));
+    CHECK(0 == sn_coap_protocol_delete_retransmission(handle, 99));
 
     sn_coap_protocol_destroy(handle);
 #endif
@@ -220,23 +221,23 @@ TEST(libCoap_protocol, sn_coap_protocol_delete_retransmission_by_token)
     dst_addr_ptr.addr_ptr = temp_addr;
     dst_addr_ptr.addr_len = 4;
     dst_addr_ptr.type = SN_NSDL_ADDRESS_TYPE_IPV4;
-    src_coap_msg_ptr.token_ptr = (uint8_t*)malloc(4);
+    src_coap_msg_ptr.token_ptr = (uint8_t *)malloc(4);
     memset(src_coap_msg_ptr.token_ptr, 0x10, 4);
     src_coap_msg_ptr.token_len = 4;
 
-    struct coap_s * handle = sn_coap_protocol_init(myMalloc, myFree, null_tx_cb, NULL);
+    struct coap_s *handle = sn_coap_protocol_init(myMalloc, myFree, null_tx_cb, NULL);
 
-    CHECK( -1 == sn_coap_protocol_delete_retransmission_by_token(NULL, NULL, 0));
+    CHECK(-1 == sn_coap_protocol_delete_retransmission_by_token(NULL, NULL, 0));
 
-    CHECK( -2 == sn_coap_protocol_delete_retransmission_by_token(handle,
-                                                                 src_coap_msg_ptr.token_ptr,
-                                                                 src_coap_msg_ptr.token_len));
+    CHECK(-2 == sn_coap_protocol_delete_retransmission_by_token(handle,
+                                                                src_coap_msg_ptr.token_ptr,
+                                                                src_coap_msg_ptr.token_len));
 
     sn_coap_builder_stub.expectedInt16 = 9;
 
-    CHECK( 0 < sn_coap_protocol_build(handle, &dst_addr_ptr, dst_packet_data_ptr, &src_coap_msg_ptr, NULL));
+    CHECK(0 < sn_coap_protocol_build(handle, &dst_addr_ptr, dst_packet_data_ptr, &src_coap_msg_ptr, NULL));
 
-    CHECK( 0 == sn_coap_protocol_delete_retransmission_by_token(handle, src_coap_msg_ptr.token_ptr, src_coap_msg_ptr.token_len));
+    CHECK(0 == sn_coap_protocol_delete_retransmission_by_token(handle, src_coap_msg_ptr.token_ptr, src_coap_msg_ptr.token_len));
 
     free(src_coap_msg_ptr.token_ptr);
     sn_coap_protocol_destroy(handle);
@@ -247,7 +248,7 @@ TEST(libCoap_protocol, sn_coap_protocol_delete_retransmission_by_token)
 TEST(libCoap_protocol, sn_coap_protocol_build)
 {
     retCounter = 1;
-    struct coap_s * handle = sn_coap_protocol_init(myMalloc, myFree, null_tx_cb, NULL);
+    struct coap_s *handle = sn_coap_protocol_init(myMalloc, myFree, null_tx_cb, NULL);
 
     sn_coap_protocol_set_retransmission_buffer(handle, 6, 0);
     sn_nsdl_addr_s addr;
@@ -255,23 +256,23 @@ TEST(libCoap_protocol, sn_coap_protocol_build)
     sn_coap_hdr_s hdr;
     memset(&hdr, 0, sizeof(sn_coap_hdr_s));
 
-    uint8_t* dst_packet_data_ptr = (uint8_t*)malloc(5);
+    uint8_t *dst_packet_data_ptr = (uint8_t *)malloc(5);
     memset(dst_packet_data_ptr, '1', 5);
 
-    CHECK( -2 == sn_coap_protocol_build(NULL, NULL, NULL, NULL, NULL));
+    CHECK(-2 == sn_coap_protocol_build(NULL, NULL, NULL, NULL, NULL));
 
-    CHECK( -2 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
+    CHECK(-2 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
 
     hdr.msg_type = COAP_MSG_TYPE_CONFIRMABLE;
     hdr.msg_id = 0;
 
-    addr.addr_ptr = (uint8_t*)malloc(5);
+    addr.addr_ptr = (uint8_t *)malloc(5);
     memset(addr.addr_ptr, '1', 5);
 
     sn_coap_builder_stub.expectedInt16 = 0;
     retCounter = 6;
 
-    CHECK( 0 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
+    CHECK(0 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
 
     // Test duplicate response sending
     addr.port = 1000;
@@ -280,17 +281,17 @@ TEST(libCoap_protocol, sn_coap_protocol_build)
     sn_coap_builder_stub.expectedInt16 = 0;
     retCounter = 3;
 
-    coap_duplication_info_s *duplicate = (coap_duplication_info_s*)malloc(sizeof(coap_duplication_info_s));
+    coap_duplication_info_s *duplicate = (coap_duplication_info_s *)malloc(sizeof(coap_duplication_info_s));
     memset(duplicate, 0, sizeof(coap_duplication_info_s));
-    duplicate->address = (sn_nsdl_addr_s*)malloc(sizeof(sn_nsdl_addr_s));
-    duplicate->address->addr_ptr = (uint8_t*)malloc(5);
+    duplicate->address = (sn_nsdl_addr_s *)malloc(sizeof(sn_nsdl_addr_s));
+    duplicate->address->addr_ptr = (uint8_t *)malloc(5);
     duplicate->address->addr_len = 5;
     memset(duplicate->address->addr_ptr, '1', 5);
     duplicate->address->port = 1000;
     duplicate->msg_id = 100;
     ns_list_add_to_end(&handle->linked_list_duplication_msgs, duplicate);
 
-    CHECK( 0 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
+    CHECK(0 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
 
     ns_list_remove(&handle->linked_list_duplication_msgs, duplicate);
     free(duplicate->address->addr_ptr);
@@ -299,7 +300,7 @@ TEST(libCoap_protocol, sn_coap_protocol_build)
     free(duplicate);
 
     hdr.msg_type = COAP_MSG_TYPE_CONFIRMABLE;
-    hdr.payload_ptr = (uint8_t*)malloc(SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20);
+    hdr.payload_ptr = (uint8_t *)malloc(SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20);
     memset(hdr.payload_ptr, '1', SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20);
     hdr.payload_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
 
@@ -307,28 +308,28 @@ TEST(libCoap_protocol, sn_coap_protocol_build)
 //    CHECK( -2 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
 
     retCounter = 0;
-    hdr.options_list_ptr = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    hdr.options_list_ptr = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(hdr.options_list_ptr, 0, sizeof(sn_coap_options_list_s));
     hdr.options_list_ptr->block1 = 67777;
 
-    CHECK( -3 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
+    CHECK(-3 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
     free(hdr.options_list_ptr);
     hdr.options_list_ptr = NULL;
 
     retCounter = 2;
-    CHECK( -3 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
+    CHECK(-3 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
 
     free(hdr.options_list_ptr);
     hdr.options_list_ptr = NULL;
 
     hdr.payload_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
     hdr.msg_code = COAP_MSG_CODE_RESPONSE_BAD_REQUEST;
-    hdr.options_list_ptr = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    hdr.options_list_ptr = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(hdr.options_list_ptr, 0, sizeof(sn_coap_options_list_s));
     hdr.options_list_ptr->block2 = 1;
     retCounter = 0;
 
-    CHECK( -3 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
+    CHECK(-3 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
     free(hdr.options_list_ptr);
     hdr.options_list_ptr = NULL;
 
@@ -337,15 +338,15 @@ TEST(libCoap_protocol, sn_coap_protocol_build)
     hdr.payload_len = 0;
 
     //Test variations of sn_coap_convert_block_size here -->
-    for( int i=0; i < 8; i++ ){
-        uint16_t multiplier = 16*pow(2, i);
-        sn_coap_protocol_set_block_size(handle,multiplier);
-        hdr.payload_ptr = (uint8_t*)malloc(multiplier + 20);
+    for (int i = 0; i < 8; i++) {
+        uint16_t multiplier = 16 * pow(2, i);
+        sn_coap_protocol_set_block_size(handle, multiplier);
+        hdr.payload_ptr = (uint8_t *)malloc(multiplier + 20);
         memset(hdr.payload_ptr, '1', multiplier + 20);
         hdr.payload_len = multiplier + 20;
         retCounter = 2;
         hdr.msg_code = COAP_MSG_CODE_RESPONSE_BAD_REQUEST;
-        CHECK( -3 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
+        CHECK(-3 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
         hdr.msg_code = COAP_MSG_CODE_EMPTY;
 
         free(hdr.options_list_ptr);
@@ -355,72 +356,72 @@ TEST(libCoap_protocol, sn_coap_protocol_build)
         hdr.payload_ptr = NULL;
         hdr.payload_len = 0;
     }
-    sn_coap_protocol_set_block_size(handle,SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE);
+    sn_coap_protocol_set_block_size(handle, SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE);
 
     // <-- Test variations of sn_coap_convert_block_size here
 
     retCounter = 1;
     sn_coap_builder_stub.expectedInt16 = -1;
-    CHECK( -1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
+    CHECK(-1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
 
     retCounter = 6;
     sn_coap_builder_stub.expectedInt16 = 1;
-    CHECK( 1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
+    CHECK(1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
 
     hdr.msg_code = COAP_MSG_CODE_EMPTY;
 
     retCounter = 7;
     sn_coap_builder_stub.expectedInt16 = 1;
-    CHECK( 1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
+    CHECK(1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
 
     retCounter = 8;
     sn_coap_builder_stub.expectedInt16 = 1;
-    CHECK( 1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
+    CHECK(1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
 
     retCounter = 9;
     sn_coap_builder_stub.expectedInt16 = 1;
-    CHECK( 1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
+    CHECK(1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
 
     retCounter = 10;
     sn_coap_builder_stub.expectedInt16 = 1;
-    CHECK( 1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
+    CHECK(1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
 
     // Test second SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE -->
-    hdr.payload_ptr = (uint8_t*)malloc(SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20);
+    hdr.payload_ptr = (uint8_t *)malloc(SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20);
     memset(hdr.payload_ptr, '1', SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20);
     hdr.payload_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
 
     sn_coap_protocol_clear_retransmission_buffer(handle);
     retCounter = 7;
     sn_coap_builder_stub.expectedInt16 = 1;
-    CHECK( 1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
+    CHECK(1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
     free(hdr.payload_ptr);
 
-    hdr.payload_ptr = (uint8_t*)malloc(SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20);
+    hdr.payload_ptr = (uint8_t *)malloc(SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20);
     memset(hdr.payload_ptr, '1', SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20);
     hdr.payload_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
 
     retCounter = 8;
     sn_coap_builder_stub.expectedInt16 = 1;
-    CHECK( 1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
+    CHECK(1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
 
     free(hdr.payload_ptr);
-    hdr.payload_ptr = (uint8_t*)malloc(UINT16_MAX);
+    hdr.payload_ptr = (uint8_t *)malloc(UINT16_MAX);
     memset(hdr.payload_ptr, '1', UINT16_MAX);
     hdr.payload_len = UINT16_MAX;
 
     retCounter = 9;
     sn_coap_builder_stub.expectedInt16 = 1;
-    CHECK( 1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
+    CHECK(1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
 
     free(hdr.payload_ptr);
-    hdr.payload_ptr = (uint8_t*)malloc(UINT16_MAX - 1);
+    hdr.payload_ptr = (uint8_t *)malloc(UINT16_MAX - 1);
     memset(hdr.payload_ptr, '1', UINT16_MAX - 1);
     hdr.payload_len = UINT16_MAX - 1;
 
     retCounter = 10;
     sn_coap_builder_stub.expectedInt16 = 1;
-    CHECK( 1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
+    CHECK(1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
 
     sn_coap_protocol_destroy(handle);
     handle = NULL;
@@ -433,17 +434,17 @@ TEST(libCoap_protocol, sn_coap_protocol_build)
     retCounter = 4;
     sn_coap_builder_stub.expectedInt16 = 1;
     hdr.payload_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
-    CHECK( -2 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
+    CHECK(-2 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
 
     free(hdr.options_list_ptr);
     hdr.options_list_ptr = NULL;
 
-    sn_coap_hdr_s* hdr2 = (sn_coap_hdr_s*)malloc(sizeof(sn_coap_hdr_s));
+    sn_coap_hdr_s *hdr2 = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
     memset(hdr2, 0, sizeof(sn_coap_hdr_s));
     hdr2->msg_type = COAP_MSG_TYPE_NON_CONFIRMABLE;
-    hdr2->uri_path_ptr = (uint8_t*)malloc(3);
+    hdr2->uri_path_ptr = (uint8_t *)malloc(3);
     hdr2->uri_path_len = 3;
-    hdr2->token_ptr = (uint8_t*)malloc(3);
+    hdr2->token_ptr = (uint8_t *)malloc(3);
     hdr2->token_len = 3;
     hdr2->content_format = COAP_CT_TEXT_PLAIN;
 
@@ -452,44 +453,44 @@ TEST(libCoap_protocol, sn_coap_protocol_build)
     hdr2->options_list_ptr->accept = COAP_CT_TEXT_PLAIN;
     hdr2->options_list_ptr->block1 = 67777;
     hdr2->options_list_ptr->block2 = 67777;
-    hdr2->options_list_ptr->etag_ptr = (uint8_t*)malloc(3);
+    hdr2->options_list_ptr->etag_ptr = (uint8_t *)malloc(3);
     hdr2->options_list_ptr->etag_len = 3;
-    hdr2->options_list_ptr->location_path_ptr = (uint8_t*)malloc(3);
+    hdr2->options_list_ptr->location_path_ptr = (uint8_t *)malloc(3);
     hdr2->options_list_ptr->location_path_len = 3;
-    hdr2->options_list_ptr->location_query_ptr = (uint8_t*)malloc(3);
+    hdr2->options_list_ptr->location_query_ptr = (uint8_t *)malloc(3);
     hdr2->options_list_ptr->location_query_len = 3;
     hdr2->options_list_ptr->max_age = 3;
     hdr2->options_list_ptr->observe = 0;
-    hdr2->options_list_ptr->proxy_uri_ptr = (uint8_t*)malloc(3);
+    hdr2->options_list_ptr->proxy_uri_ptr = (uint8_t *)malloc(3);
     hdr2->options_list_ptr->proxy_uri_len = 3;
-    hdr2->options_list_ptr->uri_host_ptr = (uint8_t*)malloc(3);
+    hdr2->options_list_ptr->uri_host_ptr = (uint8_t *)malloc(3);
     hdr2->options_list_ptr->uri_host_len = 3;
     hdr2->options_list_ptr->uri_port = 3;
-    hdr2->options_list_ptr->uri_query_ptr = (uint8_t*)malloc(3);
+    hdr2->options_list_ptr->uri_query_ptr = (uint8_t *)malloc(3);
     hdr2->options_list_ptr->uri_query_len = 3;
     hdr2->options_list_ptr->use_size1 = true;
     hdr2->options_list_ptr->size1 = 0xFFFF01;
 
     int buff_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
-    hdr2->payload_ptr = (uint8_t*)malloc(buff_len);
+    hdr2->payload_ptr = (uint8_t *)malloc(buff_len);
 
-    for( int i=1; i <= 11; i++ ){
+    for (int i = 1; i <= 11; i++) {
         retCounter = i;
         sn_coap_builder_stub.expectedInt16 = 1;
         hdr2->payload_len = buff_len;
         int8_t rett = sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, hdr2, NULL);
-        CHECK( -2 == rett );
+        CHECK(-2 == rett);
     }
 
     retCounter = 12;
     sn_coap_builder_stub.expectedInt16 = 1;
     hdr2->payload_len = buff_len;
-    CHECK( 1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, hdr2, NULL));
+    CHECK(1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, hdr2, NULL));
 
     retCounter = 12;
     sn_coap_builder_stub.expectedInt16 = 1;
     hdr2->payload_len = buff_len;
-    CHECK( 1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, hdr2, NULL));
+    CHECK(1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, hdr2, NULL));
 
     free(hdr2->payload_ptr);
     sn_coap_parser_release_allocated_coap_msg_mem(handle, hdr2);
@@ -501,7 +502,7 @@ TEST(libCoap_protocol, sn_coap_protocol_build)
     retCounter = 7;
     sn_coap_builder_stub.expectedInt16 = 1;
     hdr.payload_len = 0;
-    CHECK( 1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
+    CHECK(1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
 
     sn_coap_protocol_destroy(handle);
     handle = NULL;
@@ -511,12 +512,12 @@ TEST(libCoap_protocol, sn_coap_protocol_build)
     retCounter = 4;
     sn_coap_builder_stub.expectedInt16 = 1;
     hdr.payload_len = 0;
-    CHECK( -2 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
+    CHECK(-2 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
 
     retCounter = 8;
     sn_coap_builder_stub.expectedInt16 = 1;
     hdr.payload_len = 0;
-    CHECK( 1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
+    CHECK(1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
 
     free(hdr.payload_ptr);
     hdr.payload_ptr = NULL;
@@ -533,34 +534,34 @@ TEST(libCoap_protocol, sn_coap_protocol_build)
 
 TEST(libCoap_protocol, sn_coap_protocol_parse)
 {
-    CHECK( NULL == sn_coap_protocol_parse(NULL, NULL, 0, NULL, NULL) );
+    CHECK(NULL == sn_coap_protocol_parse(NULL, NULL, 0, NULL, NULL));
     retCounter = 1;
-    struct coap_s * handle = sn_coap_protocol_init(myMalloc, myFree, null_tx_cb, null_rx_cb);
+    struct coap_s *handle = sn_coap_protocol_init(myMalloc, myFree, null_tx_cb, null_rx_cb);
 
-    sn_nsdl_addr_s* addr = (sn_nsdl_addr_s*)malloc(sizeof(sn_nsdl_addr_s));
+    sn_nsdl_addr_s *addr = (sn_nsdl_addr_s *)malloc(sizeof(sn_nsdl_addr_s));
     memset(addr, 0, sizeof(sn_nsdl_addr_s));
 
-    addr->addr_ptr = (uint8_t*)malloc(5);
+    addr->addr_ptr = (uint8_t *)malloc(5);
 
-    uint8_t *packet_data_ptr = (uint8_t*)malloc(5);
+    uint8_t *packet_data_ptr = (uint8_t *)malloc(5);
     uint16_t packet_data_len = 5;
 
     sn_coap_parser_stub.expectedHeader = NULL;
-    CHECK( NULL == sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL) );
+    CHECK(NULL == sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL));
 
     // Failed to parse CoAP header
     sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
     sn_coap_header_check_stub.expectedInt8 = 1;
     sn_coap_parser_stub.expectedHeader->coap_status = COAP_STATUS_PARSER_ERROR_IN_HEADER;
-    CHECK( NULL == sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL) );
+    CHECK(NULL == sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL));
 
     // sn_coap_protocol_parse - message code not valid!
     sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
     sn_coap_header_check_stub.expectedInt8 = 1;
     sn_coap_parser_stub.expectedHeader->msg_code = sn_coap_msg_code_e(COAP_MSG_CODE_RESPONSE_PROXYING_NOT_SUPPORTED + 60);
-    CHECK( NULL == sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL) );
+    CHECK(NULL == sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL));
 
     // Send reset message
     sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
@@ -570,7 +571,7 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
     sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_EMPTY;
 
-    CHECK( NULL == sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL) );
+    CHECK(NULL == sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL));
 
     test_block1_receive(handle, addr, packet_data_len, packet_data_ptr);
 
@@ -593,23 +594,23 @@ TEST(libCoap_protocol, sn_coap_protocol_exec)
     CHECK(-1 == sn_coap_protocol_exec(NULL, 0));
 
     retCounter = 1;
-    struct coap_s * handle = sn_coap_protocol_init(myMalloc, myFree, null_tx_cb, NULL);
+    struct coap_s *handle = sn_coap_protocol_init(myMalloc, myFree, null_tx_cb, NULL);
 
     sn_nsdl_addr_s tmp_addr;
     memset(&tmp_addr, 0, sizeof(sn_nsdl_addr_s));
     sn_coap_hdr_s tmp_hdr;
     memset(&tmp_hdr, 0, sizeof(sn_coap_hdr_s));
 
-    uint8_t* dst_packet_data_ptr = (uint8_t*)malloc(5);
+    uint8_t *dst_packet_data_ptr = (uint8_t *)malloc(5);
     memset(dst_packet_data_ptr, '1', 5);
 
-    tmp_addr.addr_ptr = (uint8_t*)malloc(5);
+    tmp_addr.addr_ptr = (uint8_t *)malloc(5);
     memset(tmp_addr.addr_ptr, '1', 5);
 
     retCounter = 20;
     sn_coap_builder_stub.expectedInt16 = 5;
     int buff_size = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
-    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_size);
+    tmp_hdr.payload_ptr = (uint8_t *)malloc(buff_size);
     tmp_hdr.msg_id = 18;
     tmp_hdr.msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
     tmp_hdr.payload_len = buff_size;
@@ -625,23 +626,23 @@ TEST(libCoap_protocol, sn_coap_protocol_exec)
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_ACKNOWLEDGEMENT;
     sn_coap_parser_stub.expectedHeader->msg_id = 7;
 
-    sn_coap_options_list_s* list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    sn_coap_options_list_s *list = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 1;
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
     sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_REQUEST_GET;
-    uint8_t* payload = (uint8_t*)malloc(17);
+    uint8_t *payload = (uint8_t *)malloc(17);
     sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
     sn_coap_parser_stub.expectedHeader->payload_len = 17;
 
-    uint8_t *packet_data_ptr = (uint8_t*)malloc(5);
+    uint8_t *packet_data_ptr = (uint8_t *)malloc(5);
     uint16_t packet_data_len = 5;
 
-    sn_nsdl_addr_s* addr = (sn_nsdl_addr_s*)malloc(sizeof(sn_nsdl_addr_s));
+    sn_nsdl_addr_s *addr = (sn_nsdl_addr_s *)malloc(sizeof(sn_nsdl_addr_s));
     memset(addr, 0, sizeof(sn_nsdl_addr_s));
 
-    addr->addr_ptr = (uint8_t*)malloc(5);
+    addr->addr_ptr = (uint8_t *)malloc(5);
 
     retCounter = 5;
     sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
@@ -660,23 +661,23 @@ TEST(libCoap_protocol, sn_coap_protocol_exec)
 TEST(libCoap_protocol, sn_coap_protocol_exec2)
 {
     retCounter = 1;
-    struct coap_s * handle = sn_coap_protocol_init(myMalloc, myFree, null_tx_cb, null_rx_cb);
+    struct coap_s *handle = sn_coap_protocol_init(myMalloc, myFree, null_tx_cb, null_rx_cb);
 
     sn_nsdl_addr_s tmp_addr;
     memset(&tmp_addr, 0, sizeof(sn_nsdl_addr_s));
     sn_coap_hdr_s tmp_hdr;
     memset(&tmp_hdr, 0, sizeof(sn_coap_hdr_s));
 
-    uint8_t* dst_packet_data_ptr = (uint8_t*)malloc(5);
+    uint8_t *dst_packet_data_ptr = (uint8_t *)malloc(5);
     memset(dst_packet_data_ptr, '1', 5);
 
-    tmp_addr.addr_ptr = (uint8_t*)malloc(5);
+    tmp_addr.addr_ptr = (uint8_t *)malloc(5);
     memset(tmp_addr.addr_ptr, '1', 5);
 
     retCounter = 20;
     sn_coap_builder_stub.expectedInt16 = 5;
     int buf_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
-    tmp_hdr.payload_ptr = (uint8_t*)malloc(buf_len);
+    tmp_hdr.payload_ptr = (uint8_t *)malloc(buf_len);
     tmp_hdr.msg_id = 18;
     tmp_hdr.msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
     tmp_hdr.payload_len = buf_len;
@@ -692,23 +693,23 @@ TEST(libCoap_protocol, sn_coap_protocol_exec2)
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_ACKNOWLEDGEMENT;
     sn_coap_parser_stub.expectedHeader->msg_id = 7;
 
-    sn_coap_options_list_s* list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    sn_coap_options_list_s *list = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 1;
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
     sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_REQUEST_GET;
-    uint8_t* payload = (uint8_t*)malloc(17);
+    uint8_t *payload = (uint8_t *)malloc(17);
     sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
     sn_coap_parser_stub.expectedHeader->payload_len = 17;
 
-    uint8_t *packet_data_ptr = (uint8_t*)malloc(5);
+    uint8_t *packet_data_ptr = (uint8_t *)malloc(5);
     uint16_t packet_data_len = 5;
 
-    sn_nsdl_addr_s* addr = (sn_nsdl_addr_s*)malloc(sizeof(sn_nsdl_addr_s));
+    sn_nsdl_addr_s *addr = (sn_nsdl_addr_s *)malloc(sizeof(sn_nsdl_addr_s));
     memset(addr, 0, sizeof(sn_nsdl_addr_s));
 
-    addr->addr_ptr = (uint8_t*)malloc(5);
+    addr->addr_ptr = (uint8_t *)malloc(5);
 
     retCounter = 5;
     sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
@@ -720,7 +721,7 @@ TEST(libCoap_protocol, sn_coap_protocol_exec2)
     sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
 
-    sn_coap_protocol_set_retransmission_parameters(handle,0, 5);
+    sn_coap_protocol_set_retransmission_parameters(handle, 0, 5);
     CHECK(0 == sn_coap_protocol_exec(handle, 600));
 
     sn_coap_builder_stub.expectedInt16 = 0;
@@ -730,16 +731,16 @@ TEST(libCoap_protocol, sn_coap_protocol_exec2)
 
 TEST(libCoap_protocol, sn_coap_protocol_block_remove)
 {
-    sn_coap_protocol_block_remove(0,0,0,0);
+    sn_coap_protocol_block_remove(0, 0, 0, 0);
     retCounter = 9;
-    sn_nsdl_addr_s* addr = (sn_nsdl_addr_s*)malloc(sizeof(sn_nsdl_addr_s));
+    sn_nsdl_addr_s *addr = (sn_nsdl_addr_s *)malloc(sizeof(sn_nsdl_addr_s));
     memset(addr, 0, sizeof(sn_nsdl_addr_s));
-    addr->addr_ptr = (uint8_t*)malloc(5);
-    memset(addr->addr_ptr,'a',5);
+    addr->addr_ptr = (uint8_t *)malloc(5);
+    memset(addr->addr_ptr, 'a', 5);
     addr->addr_len = 5;
-    struct coap_s * handle = sn_coap_protocol_init(myMalloc, myFree, null_tx_cb, NULL);
-    uint8_t *packet_data_ptr = (uint8_t*)malloc(5);
-    memset(packet_data_ptr,'x',5);
+    struct coap_s *handle = sn_coap_protocol_init(myMalloc, myFree, null_tx_cb, NULL);
+    uint8_t *packet_data_ptr = (uint8_t *)malloc(5);
+    memset(packet_data_ptr, 'x', 5);
     uint16_t packet_data_len = 5;
     sn_coap_parser_stub.expectedHeader = NULL;
     sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
@@ -747,13 +748,13 @@ TEST(libCoap_protocol, sn_coap_protocol_block_remove)
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_ACKNOWLEDGEMENT;
     sn_coap_parser_stub.expectedHeader->msg_id = 13;
 
-    sn_coap_options_list_s* list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    sn_coap_options_list_s *list = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 0x08;
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
     sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_REQUEST_PUT;
-    uint8_t* payload = (uint8_t*)malloc(17);
+    uint8_t *payload = (uint8_t *)malloc(17);
     sn_coap_parser_stub.expectedHeader->payload_ptr = packet_data_ptr;
     sn_coap_parser_stub.expectedHeader->payload_len = packet_data_len;
     sn_coap_builder_stub.expectedUint16 = 1;
@@ -762,7 +763,7 @@ TEST(libCoap_protocol, sn_coap_protocol_block_remove)
     retCounter = 19;
     sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
     CHECK(ns_list_count(&handle->linked_list_blockwise_received_payloads) == 1);
-    sn_coap_protocol_block_remove(handle,addr,packet_data_len,packet_data_ptr);
+    sn_coap_protocol_block_remove(handle, addr, packet_data_len, packet_data_ptr);
     CHECK(ns_list_count(&handle->linked_list_blockwise_received_payloads) == 0);
 
     // Ports does not match
@@ -773,7 +774,7 @@ TEST(libCoap_protocol, sn_coap_protocol_block_remove)
     sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
     CHECK(ns_list_count(&handle->linked_list_blockwise_received_payloads) == 1);
     addr->port = 5601;
-    sn_coap_protocol_block_remove(handle,addr,packet_data_len,packet_data_ptr);
+    sn_coap_protocol_block_remove(handle, addr, packet_data_len, packet_data_ptr);
     CHECK(ns_list_count(&handle->linked_list_blockwise_received_payloads) == 1);
 
     // Addresses does not match
@@ -783,12 +784,12 @@ TEST(libCoap_protocol, sn_coap_protocol_block_remove)
     sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
     CHECK(ns_list_count(&handle->linked_list_blockwise_received_payloads) == 2);
     addr->addr_ptr[0] = 'x';
-    sn_coap_protocol_block_remove(handle,addr,packet_data_len,packet_data_ptr);
+    sn_coap_protocol_block_remove(handle, addr, packet_data_len, packet_data_ptr);
     CHECK(ns_list_count(&handle->linked_list_blockwise_received_payloads) == 2);
 
     // Payload length does not match
     addr->addr_ptr[0] = 'a';
-    sn_coap_protocol_block_remove(handle,addr,packet_data_len+1,packet_data_ptr);
+    sn_coap_protocol_block_remove(handle, addr, packet_data_len + 1, packet_data_ptr);
     CHECK(ns_list_count(&handle->linked_list_blockwise_received_payloads) == 2);
 
     free(sn_coap_parser_stub.expectedHeader->options_list_ptr);
@@ -802,12 +803,12 @@ TEST(libCoap_protocol, sn_coap_protocol_block_remove)
 
 TEST(libCoap_protocol, sn_coap_protocol_remove_sent_blockwise_message)
 {
-    sn_coap_protocol_remove_sent_blockwise_message(0,0);
+    sn_coap_protocol_remove_sent_blockwise_message(0, 0);
     retCounter = 9;
-    struct coap_s * handle = sn_coap_protocol_init(myMalloc, myFree, null_tx_cb, NULL);
+    struct coap_s *handle = sn_coap_protocol_init(myMalloc, myFree, null_tx_cb, NULL);
     coap_blockwise_msg_s *message = (coap_blockwise_msg_s *)malloc(sizeof(coap_blockwise_msg_s));
     memset(message, 0, sizeof(coap_blockwise_msg_s));
-    message->coap_msg_ptr = (sn_coap_hdr_s*)malloc(sizeof(sn_coap_hdr_s));
+    message->coap_msg_ptr = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
     memset(message->coap_msg_ptr, 0, sizeof(sn_coap_hdr_s));
     message->coap_msg_ptr->msg_id = 100;
     ns_list_add_to_end(&handle->linked_list_blockwise_sent_msgs, message);
@@ -821,9 +822,9 @@ TEST(libCoap_protocol, sn_coap_protocol_remove_sent_blockwise_message)
 
 TEST(libCoap_protocol, sn_coap_protocol_handle_block2_response_internally)
 {
-    sn_coap_protocol_handle_block2_response_internally(0,0);
+    sn_coap_protocol_handle_block2_response_internally(0, 0);
     retCounter = 9;
-    struct coap_s * handle = sn_coap_protocol_init(myMalloc, myFree, null_tx_cb, NULL);
+    struct coap_s *handle = sn_coap_protocol_init(myMalloc, myFree, null_tx_cb, NULL);
     sn_coap_protocol_handle_block2_response_internally(handle, true);
     CHECK(handle->sn_coap_internal_block2_resp_handling == true);
     sn_coap_protocol_handle_block2_response_internally(handle, false);
@@ -834,7 +835,7 @@ TEST(libCoap_protocol, sn_coap_protocol_handle_block2_response_internally)
 TEST(libCoap_protocol, sn_coap_protocol_get_configured_blockwise_size)
 {
     retCounter = 9;
-    struct coap_s * handle = sn_coap_protocol_init(myMalloc, myFree, null_tx_cb, NULL);
+    struct coap_s *handle = sn_coap_protocol_init(myMalloc, myFree, null_tx_cb, NULL);
     CHECK(sn_coap_protocol_get_configured_blockwise_size(handle) == SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE);
     sn_coap_protocol_destroy(handle);
 }
@@ -845,7 +846,7 @@ void test_block1_receive(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t p
     sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
 
-    sn_coap_options_list_s* list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    sn_coap_options_list_s *list = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 1;
@@ -854,17 +855,17 @@ void test_block1_receive(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t p
     sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_REQUEST_GET;
 
     sn_coap_hdr_s *ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
-    CHECK( NULL == ret );
+    CHECK(NULL == ret);
     CHECK(ns_list_count(&handle->linked_list_blockwise_received_payloads) == 0);
 
     // sn_coap_protocol_linked_list_blockwise_payload_store - failed to allocate blockwise!
-    uint8_t* payload = (uint8_t*)malloc(5);
+    uint8_t *payload = (uint8_t *)malloc(5);
     sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
     sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
     sn_coap_parser_stub.expectedHeader->payload_len = 5;
 
-    list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    list = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 1;
@@ -873,18 +874,18 @@ void test_block1_receive(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t p
     sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_REQUEST_GET;
 
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
-    CHECK( NULL == ret );
+    CHECK(NULL == ret);
     CHECK(ns_list_count(&handle->linked_list_blockwise_received_payloads) == 0);
     free(payload);
 
     // sn_coap_protocol_linked_list_blockwise_payload_store - failed to allocate payload!
-    payload = (uint8_t*)malloc(5);
+    payload = (uint8_t *)malloc(5);
     sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
     sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
     sn_coap_parser_stub.expectedHeader->payload_len = 5;
 
-    list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    list = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 1;
@@ -894,18 +895,18 @@ void test_block1_receive(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t p
 
     retCounter = 4;
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
-    CHECK( NULL == ret );
+    CHECK(NULL == ret);
     CHECK(ns_list_count(&handle->linked_list_blockwise_received_payloads) == 0);
     free(payload);
 
     // sn_coap_protocol_linked_list_blockwise_payload_store - failed to allocate address pointer!
-    payload = (uint8_t*)malloc(5);
+    payload = (uint8_t *)malloc(5);
     sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
     sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
     sn_coap_parser_stub.expectedHeader->payload_len = 5;
 
-    list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    list = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 1;
@@ -915,12 +916,12 @@ void test_block1_receive(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t p
 
     retCounter = 5;
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
-    CHECK( NULL == ret );
+    CHECK(NULL == ret);
     CHECK(ns_list_count(&handle->linked_list_blockwise_received_payloads) == 0);
     free(payload);
 
     // sn_coap_protocol_linked_list_blockwise_payload_store - failed to allocate token pointer!
-    payload = (uint8_t*)malloc(5);
+    payload = (uint8_t *)malloc(5);
     sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
     sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
@@ -928,10 +929,10 @@ void test_block1_receive(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t p
 
     uint32_t token = 1000;
     sn_coap_parser_stub.expectedHeader->token_len = sizeof(uint32_t);
-    sn_coap_parser_stub.expectedHeader->token_ptr = (uint8_t*)malloc(sizeof(uint32_t));
+    sn_coap_parser_stub.expectedHeader->token_ptr = (uint8_t *)malloc(sizeof(uint32_t));
     memcpy(sn_coap_parser_stub.expectedHeader->token_ptr, &token, sizeof(uint32_t));
 
-    list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    list = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 1;
@@ -941,22 +942,22 @@ void test_block1_receive(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t p
 
     retCounter = 6;
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
-    CHECK( NULL == ret );
+    CHECK(NULL == ret);
     CHECK(ns_list_count(&handle->linked_list_blockwise_received_payloads) == 0);
     free(payload);
 
     // sn_coap_protocol_linked_list_blockwise_payload_store - success
-    payload = (uint8_t*)malloc(5);
+    payload = (uint8_t *)malloc(5);
     sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
     sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
     sn_coap_parser_stub.expectedHeader->payload_len = 5;
 
     sn_coap_parser_stub.expectedHeader->token_len = sizeof(uint32_t);
-    sn_coap_parser_stub.expectedHeader->token_ptr = (uint8_t*)malloc(sizeof(uint32_t));
+    sn_coap_parser_stub.expectedHeader->token_ptr = (uint8_t *)malloc(sizeof(uint32_t));
     memcpy(sn_coap_parser_stub.expectedHeader->token_ptr, &token, sizeof(uint32_t));
 
-    list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    list = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 1;
@@ -966,7 +967,7 @@ void test_block1_receive(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t p
 
     retCounter = 8;
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
-    CHECK( ret );
+    CHECK(ret);
     CHECK(ns_list_count(&handle->linked_list_blockwise_received_payloads) == 1);
     free(payload);
 #if !SN_COAP_REDUCE_BLOCKWISE_HEAP_FOOTPRINT
@@ -976,17 +977,17 @@ void test_block1_receive(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t p
 
 
     // sn_coap_protocol_linked_list_blockwise_payload_store - success, reallocate
-    payload = (uint8_t*)malloc(5);
+    payload = (uint8_t *)malloc(5);
     sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
     sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
     sn_coap_parser_stub.expectedHeader->payload_len = 5;
 
     sn_coap_parser_stub.expectedHeader->token_len = sizeof(uint32_t);
-    sn_coap_parser_stub.expectedHeader->token_ptr = (uint8_t*)malloc(sizeof(uint32_t));
+    sn_coap_parser_stub.expectedHeader->token_ptr = (uint8_t *)malloc(sizeof(uint32_t));
     memcpy(sn_coap_parser_stub.expectedHeader->token_ptr, &token, sizeof(uint32_t));
 
-    list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    list = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 0x10;
@@ -997,7 +998,7 @@ void test_block1_receive(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t p
     retCounter = 7;
     // Update existing block data payload
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
-    CHECK( ret );
+    CHECK(ret);
     CHECK(ns_list_count(&handle->linked_list_blockwise_received_payloads) == 1);
     CHECK(ret->payload_len == 10);
 #if !SN_COAP_REDUCE_BLOCKWISE_HEAP_FOOTPRINT
@@ -1007,17 +1008,17 @@ void test_block1_receive(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t p
     sn_coap_parser_release_allocated_coap_msg_mem(handle, sn_coap_parser_stub.expectedHeader);
 
     // sn_coap_protocol_linked_list_blockwise_payload_store - failed to allocate temp buffer!
-    payload = (uint8_t*)malloc(5);
+    payload = (uint8_t *)malloc(5);
     sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
     sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
     sn_coap_parser_stub.expectedHeader->payload_len = 5;
 
     sn_coap_parser_stub.expectedHeader->token_len = sizeof(uint32_t);
-    sn_coap_parser_stub.expectedHeader->token_ptr = (uint8_t*)malloc(sizeof(uint32_t));
+    sn_coap_parser_stub.expectedHeader->token_ptr = (uint8_t *)malloc(sizeof(uint32_t));
     memcpy(sn_coap_parser_stub.expectedHeader->token_ptr, &token, sizeof(uint32_t));
 
-    list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    list = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 0x20;
@@ -1027,21 +1028,21 @@ void test_block1_receive(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t p
 
     retCounter = 3;
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
-    CHECK( ret == NULL );
+    CHECK(ret == NULL);
     free(payload);
 
     // sn_coap_protocol_linked_list_blockwise_payload_store - success
-    payload = (uint8_t*)malloc(5);
+    payload = (uint8_t *)malloc(5);
     sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
     sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
     sn_coap_parser_stub.expectedHeader->payload_len = 5;
 
     sn_coap_parser_stub.expectedHeader->token_len = sizeof(uint32_t);
-    sn_coap_parser_stub.expectedHeader->token_ptr = (uint8_t*)malloc(sizeof(uint32_t));
+    sn_coap_parser_stub.expectedHeader->token_ptr = (uint8_t *)malloc(sizeof(uint32_t));
     memcpy(sn_coap_parser_stub.expectedHeader->token_ptr, &token, sizeof(uint32_t));
 
-    list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    list = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 1;
@@ -1051,7 +1052,7 @@ void test_block1_receive(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t p
 
     retCounter = 8;
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
-    CHECK( ret );
+    CHECK(ret);
     CHECK(ns_list_count(&handle->linked_list_blockwise_received_payloads) == 1);
     free(payload);
 #if !SN_COAP_REDUCE_BLOCKWISE_HEAP_FOOTPRINT
@@ -1060,17 +1061,17 @@ void test_block1_receive(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t p
     sn_coap_parser_release_allocated_coap_msg_mem(handle, sn_coap_parser_stub.expectedHeader);
 
     // sn_coap_protocol_linked_list_blockwise_payload_store - failed to reallocate payload!
-    payload = (uint8_t*)malloc(5);
+    payload = (uint8_t *)malloc(5);
     sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
     sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
     sn_coap_parser_stub.expectedHeader->payload_len = 5;
 
     sn_coap_parser_stub.expectedHeader->token_len = sizeof(uint32_t);
-    sn_coap_parser_stub.expectedHeader->token_ptr = (uint8_t*)malloc(sizeof(uint32_t));
+    sn_coap_parser_stub.expectedHeader->token_ptr = (uint8_t *)malloc(sizeof(uint32_t));
     memcpy(sn_coap_parser_stub.expectedHeader->token_ptr, &token, sizeof(uint32_t));
 
-    list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    list = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 0x20;
@@ -1080,22 +1081,22 @@ void test_block1_receive(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t p
 
     retCounter = 4;
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
-    CHECK( ret == NULL );
+    CHECK(ret == NULL);
     free(payload);
 
 
     // sn_coap_protocol_linked_list_blockwise_payload_store - success, size1 present
-    payload = (uint8_t*)malloc(16);
+    payload = (uint8_t *)malloc(16);
     sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
     sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
     sn_coap_parser_stub.expectedHeader->payload_len = 16;
 
     sn_coap_parser_stub.expectedHeader->token_len = sizeof(uint32_t);
-    sn_coap_parser_stub.expectedHeader->token_ptr = (uint8_t*)malloc(sizeof(uint32_t));
+    sn_coap_parser_stub.expectedHeader->token_ptr = (uint8_t *)malloc(sizeof(uint32_t));
     memcpy(sn_coap_parser_stub.expectedHeader->token_ptr, &token, sizeof(uint32_t));
 
-    list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    list = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 1;
@@ -1106,7 +1107,7 @@ void test_block1_receive(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t p
 
     retCounter = 8;
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
-    CHECK( ret );
+    CHECK(ret);
     CHECK(ns_list_count(&handle->linked_list_blockwise_received_payloads) == 1);
     free(payload);
 
@@ -1118,17 +1119,17 @@ void test_block1_receive(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t p
 
 
     // sn_coap_protocol_linked_list_blockwise_payload_store - success, size1, update block payload
-    payload = (uint8_t*)malloc(4);
+    payload = (uint8_t *)malloc(4);
     sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
     sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
     sn_coap_parser_stub.expectedHeader->payload_len = 4;
 
     sn_coap_parser_stub.expectedHeader->token_len = sizeof(uint32_t);
-    sn_coap_parser_stub.expectedHeader->token_ptr = (uint8_t*)malloc(sizeof(uint32_t));
+    sn_coap_parser_stub.expectedHeader->token_ptr = (uint8_t *)malloc(sizeof(uint32_t));
     memcpy(sn_coap_parser_stub.expectedHeader->token_ptr, &token, sizeof(uint32_t));
 
-    list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    list = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 0x10;
@@ -1138,7 +1139,7 @@ void test_block1_receive(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t p
 
     retCounter = 7;
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
-    CHECK( ret );
+    CHECK(ret);
     CHECK(ns_list_count(&handle->linked_list_blockwise_received_payloads) == 1);
     CHECK(ret->payload_len == 20);
 
@@ -1154,17 +1155,17 @@ void test_block1_receive(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t p
     // continue block1 testing -->
 
     // sn_coap_handle_blockwise_message - (recv block1) failed to allocate ack message!
-    payload = (uint8_t*)malloc(16);
+    payload = (uint8_t *)malloc(16);
     sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
     sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
     sn_coap_parser_stub.expectedHeader->payload_len = 16;
 
     sn_coap_parser_stub.expectedHeader->token_len = sizeof(uint32_t);
-    sn_coap_parser_stub.expectedHeader->token_ptr = (uint8_t*)malloc(sizeof(uint32_t));
+    sn_coap_parser_stub.expectedHeader->token_ptr = (uint8_t *)malloc(sizeof(uint32_t));
     memcpy(sn_coap_parser_stub.expectedHeader->token_ptr, &token, sizeof(uint32_t));
 
-    list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    list = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 0x08;
@@ -1175,23 +1176,23 @@ void test_block1_receive(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t p
 
     retCounter = 3;
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
-    CHECK( ret == NULL );
+    CHECK(ret == NULL);
     CHECK(ns_list_count(&handle->linked_list_blockwise_received_payloads) == 0);
     free(payload);
 
 
     // sn_coap_handle_blockwise_message - (recv block1) COAP_MSG_CODE_RESPONSE_REQUEST_ENTITY_TOO_LARGE!
-    payload = (uint8_t*)malloc(16);
+    payload = (uint8_t *)malloc(16);
     sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
     sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
     sn_coap_parser_stub.expectedHeader->payload_len = 16;
 
     sn_coap_parser_stub.expectedHeader->token_len = sizeof(uint32_t);
-    sn_coap_parser_stub.expectedHeader->token_ptr = (uint8_t*)malloc(sizeof(uint32_t));
+    sn_coap_parser_stub.expectedHeader->token_ptr = (uint8_t *)malloc(sizeof(uint32_t));
     memcpy(sn_coap_parser_stub.expectedHeader->token_ptr, &token, sizeof(uint32_t));
 
-    list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    list = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 0x08;
@@ -1202,23 +1203,23 @@ void test_block1_receive(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t p
 
     retCounter = 8;
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
-    CHECK( ret );
+    CHECK(ret);
     CHECK(ns_list_count(&handle->linked_list_blockwise_received_payloads) == 0);
     sn_coap_parser_release_allocated_coap_msg_mem(handle, sn_coap_parser_stub.expectedHeader);
     free(payload);
 
     // sn_coap_handle_blockwise_message - (recv block1) block size1 bigger than configured block size
-    payload = (uint8_t*)malloc(16);
+    payload = (uint8_t *)malloc(16);
     sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
     sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
     sn_coap_parser_stub.expectedHeader->payload_len = 16;
 
     sn_coap_parser_stub.expectedHeader->token_len = sizeof(uint32_t);
-    sn_coap_parser_stub.expectedHeader->token_ptr = (uint8_t*)malloc(sizeof(uint32_t));
+    sn_coap_parser_stub.expectedHeader->token_ptr = (uint8_t *)malloc(sizeof(uint32_t));
     memcpy(sn_coap_parser_stub.expectedHeader->token_ptr, &token, sizeof(uint32_t));
 
-    list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    list = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
     // Block1 size 128 bytes
@@ -1230,24 +1231,24 @@ void test_block1_receive(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t p
 
     retCounter = 8;
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
-    CHECK( ret );
+    CHECK(ret);
     CHECK(ns_list_count(&handle->linked_list_blockwise_received_payloads) == 0);
     sn_coap_parser_release_allocated_coap_msg_mem(handle, sn_coap_parser_stub.expectedHeader);
     sn_coap_protocol_clear_received_blockwise_messages(handle);
     free(payload);
 
     // sn_coap_protocol_update_duplication_package_data - failed to allocate duplication info!
-    payload = (uint8_t*)malloc(16);
+    payload = (uint8_t *)malloc(16);
     sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
     sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
     sn_coap_parser_stub.expectedHeader->payload_len = 16;
 
     sn_coap_parser_stub.expectedHeader->token_len = sizeof(uint32_t);
-    sn_coap_parser_stub.expectedHeader->token_ptr = (uint8_t*)malloc(sizeof(uint32_t));
+    sn_coap_parser_stub.expectedHeader->token_ptr = (uint8_t *)malloc(sizeof(uint32_t));
     memcpy(sn_coap_parser_stub.expectedHeader->token_ptr, &token, sizeof(uint32_t));
 
-    list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    list = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 0x08;
@@ -1258,22 +1259,22 @@ void test_block1_receive(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t p
 
     retCounter = 7;
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
-    CHECK( ret == NULL);
+    CHECK(ret == NULL);
     CHECK(ns_list_count(&handle->linked_list_blockwise_received_payloads) == 0);
     free(payload);
 
     // sn_coap_handle_blockwise_message - (recv block1) message allocation failed!
-    payload = (uint8_t*)malloc(16);
+    payload = (uint8_t *)malloc(16);
     sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
     sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
     sn_coap_parser_stub.expectedHeader->payload_len = 16;
 
     sn_coap_parser_stub.expectedHeader->token_len = sizeof(uint32_t);
-    sn_coap_parser_stub.expectedHeader->token_ptr = (uint8_t*)malloc(sizeof(uint32_t));
+    sn_coap_parser_stub.expectedHeader->token_ptr = (uint8_t *)malloc(sizeof(uint32_t));
     memcpy(sn_coap_parser_stub.expectedHeader->token_ptr, &token, sizeof(uint32_t));
 
-    list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    list = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 0x08;
@@ -1284,7 +1285,7 @@ void test_block1_receive(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t p
 
     retCounter = 5;
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
-    CHECK( ret == NULL);
+    CHECK(ret == NULL);
     CHECK(ns_list_count(&handle->linked_list_blockwise_received_payloads) == 0);
     free(payload);
 }
@@ -1296,20 +1297,20 @@ void test_block1_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_ACKNOWLEDGEMENT;
     sn_coap_parser_stub.expectedHeader->msg_id = 15;
 
-    sn_coap_options_list_s* list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    sn_coap_options_list_s *list = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 0x00;
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
     sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
-    uint8_t *payload = (uint8_t*)malloc(17);
+    uint8_t *payload = (uint8_t *)malloc(17);
     sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
     sn_coap_parser_stub.expectedHeader->payload_len = 17;
 
     retCounter = 2;
     sn_coap_hdr_s *ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
-    CHECK( NULL != ret );
-    CHECK( COAP_STATUS_OK == ret->coap_status );
+    CHECK(NULL != ret);
+    CHECK(COAP_STATUS_OK == ret->coap_status);
     free(payload);
     free(list);
     free(sn_coap_parser_stub.expectedHeader);
@@ -1319,20 +1320,20 @@ void test_block1_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_ACKNOWLEDGEMENT;
     sn_coap_parser_stub.expectedHeader->msg_id = 15;
 
-    list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    list = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 0x08;
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
     sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
-    payload = (uint8_t*)malloc(17);
+    payload = (uint8_t *)malloc(17);
     sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
     sn_coap_parser_stub.expectedHeader->payload_len = 17;
 
     retCounter = 2;
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
-    CHECK( NULL != ret );
-    CHECK( COAP_STATUS_OK == ret->coap_status );
+    CHECK(NULL != ret);
+    CHECK(COAP_STATUS_PARSER_BLOCKWISE_ACK == ret->coap_status);
     free(payload);
     free(list);
     free(sn_coap_parser_stub.expectedHeader);
@@ -1343,27 +1344,27 @@ void test_block1_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_ACKNOWLEDGEMENT;
     sn_coap_parser_stub.expectedHeader->msg_id = 16;
 
-    list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    list = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 0x08;
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
     sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_RESPONSE_CONTINUE;
-    payload = (uint8_t*)malloc(16);
+    payload = (uint8_t *)malloc(16);
     sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
     sn_coap_parser_stub.expectedHeader->payload_len = 16;
 
     sn_coap_hdr_s tmp_hdr;
     memset(&tmp_hdr, 0, sizeof(sn_coap_hdr_s));
 
-    uint8_t* dst_packet_data_ptr = (uint8_t*)malloc(5);
+    uint8_t *dst_packet_data_ptr = (uint8_t *)malloc(5);
     memset(dst_packet_data_ptr, '1', 5);
 
     retCounter = 20;
     sn_coap_builder_stub.expectedInt16 = 1;
     int buff_size = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 17;
-    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_size);
-    tmp_hdr.options_list_ptr = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    tmp_hdr.payload_ptr = (uint8_t *)malloc(buff_size);
+    tmp_hdr.options_list_ptr = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(tmp_hdr.options_list_ptr, 0, sizeof(sn_coap_options_list_s));
     tmp_hdr.options_list_ptr->block2 = 1;
     tmp_hdr.msg_id = 16;
@@ -1378,8 +1379,8 @@ void test_block1_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
 
     retCounter = 7;
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
-    CHECK( NULL != ret );
-    CHECK( ret->coap_status == COAP_STATUS_PARSER_BLOCKWISE_ACK );
+    CHECK(NULL != ret);
+    CHECK(ret->coap_status == COAP_STATUS_PARSER_BLOCKWISE_ACK);
     free(payload);
     sn_coap_parser_release_allocated_coap_msg_mem(handle, sn_coap_parser_stub.expectedHeader);
     sn_coap_protocol_clear_sent_blockwise_messages(handle);
@@ -1391,25 +1392,25 @@ void test_block1_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_ACKNOWLEDGEMENT;
     sn_coap_parser_stub.expectedHeader->msg_id = 17;
 
-    list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    list = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 0x18;
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
     sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
-    payload = (uint8_t*)malloc(16);
+    payload = (uint8_t *)malloc(16);
     sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
     sn_coap_parser_stub.expectedHeader->payload_len = 16;
 
     memset(&tmp_hdr, 0, sizeof(sn_coap_hdr_s));
-    dst_packet_data_ptr = (uint8_t*)malloc(5);
+    dst_packet_data_ptr = (uint8_t *)malloc(5);
     memset(dst_packet_data_ptr, '1', 5);
 
     retCounter = 20;
     sn_coap_builder_stub.expectedInt16 = 1;
     buff_size = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 17;
-    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_size);
-    tmp_hdr.options_list_ptr = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    tmp_hdr.payload_ptr = (uint8_t *)malloc(buff_size);
+    tmp_hdr.options_list_ptr = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(tmp_hdr.options_list_ptr, 0, sizeof(sn_coap_options_list_s));
     tmp_hdr.options_list_ptr->block2 = 1;
     tmp_hdr.msg_id = 17;
@@ -1424,10 +1425,10 @@ void test_block1_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
 
     retCounter = 7;
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
-    CHECK( NULL != ret );
-    CHECK( ret->coap_status == COAP_STATUS_PARSER_BLOCKWISE_ACK );
+    CHECK(NULL != ret);
+    CHECK(ret->coap_status == COAP_STATUS_PARSER_BLOCKWISE_ACK);
     // Last block sent, list should be empty now
-    CHECK( ns_list_count(&handle->linked_list_blockwise_sent_msgs) == 0 );
+    CHECK(ns_list_count(&handle->linked_list_blockwise_sent_msgs) == 0);
     free(payload);
     sn_coap_parser_release_allocated_coap_msg_mem(handle, sn_coap_parser_stub.expectedHeader);
     sn_coap_protocol_clear_retransmission_buffer(handle);
@@ -1438,25 +1439,25 @@ void test_block1_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_ACKNOWLEDGEMENT;
     sn_coap_parser_stub.expectedHeader->msg_id = 18;
 
-    list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    list = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 0x18;
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
     sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
-    payload = (uint8_t*)malloc(16);
+    payload = (uint8_t *)malloc(16);
     sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
     sn_coap_parser_stub.expectedHeader->payload_len = 16;
 
     memset(&tmp_hdr, 0, sizeof(sn_coap_hdr_s));
-    dst_packet_data_ptr = (uint8_t*)malloc(5);
+    dst_packet_data_ptr = (uint8_t *)malloc(5);
     memset(dst_packet_data_ptr, '1', 5);
 
     retCounter = 20;
     sn_coap_builder_stub.expectedInt16 = 1;
     buff_size = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 17;
-    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_size);
-    tmp_hdr.options_list_ptr = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    tmp_hdr.payload_ptr = (uint8_t *)malloc(buff_size);
+    tmp_hdr.options_list_ptr = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(tmp_hdr.options_list_ptr, 0, sizeof(sn_coap_options_list_s));
     tmp_hdr.options_list_ptr->block2 = 1;
     tmp_hdr.msg_id = 18;
@@ -1471,7 +1472,7 @@ void test_block1_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
 
     retCounter = 3;
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
-    CHECK( NULL == ret );
+    CHECK(NULL == ret);
     free(payload);
     sn_coap_protocol_clear_sent_blockwise_messages(handle);
 
@@ -1481,22 +1482,22 @@ void test_block1_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_ACKNOWLEDGEMENT;
     sn_coap_parser_stub.expectedHeader->msg_id = 19;
 
-    list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    list = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 0xe808;
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
     sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
-    payload = (uint8_t*)malloc(17);
+    payload = (uint8_t *)malloc(17);
     sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
     sn_coap_parser_stub.expectedHeader->payload_len = 17;
 
     memset(&tmp_hdr, 0, sizeof(sn_coap_hdr_s));
-    dst_packet_data_ptr = (uint8_t*)malloc(5);
+    dst_packet_data_ptr = (uint8_t *)malloc(5);
     memset(dst_packet_data_ptr, '1', 5);
     retCounter = 20;
     sn_coap_builder_stub.expectedInt16 = 1;
-    tmp_hdr.payload_ptr = (uint8_t*)malloc(UINT16_MAX);
+    tmp_hdr.payload_ptr = (uint8_t *)malloc(UINT16_MAX);
     tmp_hdr.msg_id = 19;
     tmp_hdr.msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
     tmp_hdr.payload_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
@@ -1515,7 +1516,7 @@ void test_block1_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
 
     retCounter = 2;
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
-    CHECK( NULL == ret );
+    CHECK(NULL == ret);
     free(payload);
     sn_coap_protocol_clear_retransmission_buffer(handle);
     sn_coap_protocol_clear_sent_blockwise_messages(handle);
@@ -1529,36 +1530,36 @@ void test_block2_receive(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t p
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_ACKNOWLEDGEMENT;
     sn_coap_parser_stub.expectedHeader->msg_id = 20;
 
-    sn_coap_options_list_s *list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    sn_coap_options_list_s *list = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = -1;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block2 = 0x08;
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
     sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_REQUEST_DELETE;
-    uint8_t *payload = (uint8_t*)malloc(17);
+    uint8_t *payload = (uint8_t *)malloc(17);
     sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
     sn_coap_parser_stub.expectedHeader->payload_len = 17;
     sn_coap_parser_stub.expectedHeader->token_len = 4;
-    sn_coap_parser_stub.expectedHeader->token_ptr = (uint8_t*)malloc(4);
+    sn_coap_parser_stub.expectedHeader->token_ptr = (uint8_t *)malloc(4);
     memset(sn_coap_parser_stub.expectedHeader->token_ptr, '1', 4);
 
     sn_coap_hdr_s tmp_hdr;
     memset(&tmp_hdr, 0, sizeof(sn_coap_hdr_s));
 
-    uint8_t *dst_packet_data_ptr = (uint8_t*)malloc(5);
+    uint8_t *dst_packet_data_ptr = (uint8_t *)malloc(5);
     memset(dst_packet_data_ptr, '1', 5);
 
     retCounter = 20;
     sn_coap_builder_stub.expectedInt16 = 1;
     int buff_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
-    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_len);
+    tmp_hdr.payload_ptr = (uint8_t *)malloc(buff_len);
 
     tmp_hdr.msg_id = 20;
     tmp_hdr.msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
     tmp_hdr.payload_len = buff_len;
     tmp_hdr.token_len = 4;
-    tmp_hdr.token_ptr = (uint8_t*)malloc(4);
+    tmp_hdr.token_ptr = (uint8_t *)malloc(4);
     memset(tmp_hdr.token_ptr, '1', 4);
     sn_coap_protocol_build(handle, addr, dst_packet_data_ptr, &tmp_hdr, NULL);
 
@@ -1571,8 +1572,8 @@ void test_block2_receive(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t p
 
     retCounter = 7;
     sn_coap_hdr_s *ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
-    CHECK( NULL != ret );
-    CHECK( COAP_STATUS_PARSER_BLOCKWISE_ACK == ret->coap_status );
+    CHECK(NULL != ret);
+    CHECK(COAP_STATUS_PARSER_BLOCKWISE_ACK == ret->coap_status);
     free(payload);
     sn_coap_parser_release_allocated_coap_msg_mem(handle, sn_coap_parser_stub.expectedHeader);
     sn_coap_protocol_clear_sent_blockwise_messages(handle);
@@ -1584,34 +1585,34 @@ void test_block2_receive(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t p
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_ACKNOWLEDGEMENT;
     sn_coap_parser_stub.expectedHeader->msg_id = 21;
 
-    list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    list = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = -1;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block2 = 0x1b;
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
     sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_REQUEST_DELETE;
-    payload = (uint8_t*)malloc(17);
+    payload = (uint8_t *)malloc(17);
     sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
     sn_coap_parser_stub.expectedHeader->payload_len = 17;
     sn_coap_parser_stub.expectedHeader->token_len = 4;
-    sn_coap_parser_stub.expectedHeader->token_ptr = (uint8_t*)malloc(4);
+    sn_coap_parser_stub.expectedHeader->token_ptr = (uint8_t *)malloc(4);
     memset(sn_coap_parser_stub.expectedHeader->token_ptr, '1', 4);
 
     memset(&tmp_hdr, 0, sizeof(sn_coap_hdr_s));
-    dst_packet_data_ptr = (uint8_t*)malloc(5);
+    dst_packet_data_ptr = (uint8_t *)malloc(5);
     memset(dst_packet_data_ptr, '1', 5);
 
     retCounter = 20;
     sn_coap_builder_stub.expectedInt16 = 1;
     buff_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
-    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_len);
+    tmp_hdr.payload_ptr = (uint8_t *)malloc(buff_len);
 
     tmp_hdr.msg_id = 21;
     tmp_hdr.msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
     tmp_hdr.payload_len = buff_len;
     tmp_hdr.token_len = 4;
-    tmp_hdr.token_ptr = (uint8_t*)malloc(4);
+    tmp_hdr.token_ptr = (uint8_t *)malloc(4);
     memset(tmp_hdr.token_ptr, '1', 4);
     sn_coap_protocol_build(handle, addr, dst_packet_data_ptr, &tmp_hdr, NULL);
 
@@ -1624,8 +1625,8 @@ void test_block2_receive(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t p
 
     retCounter = 7;
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
-    CHECK( NULL != ret );
-    CHECK( COAP_STATUS_PARSER_BLOCKWISE_ACK == ret->coap_status );
+    CHECK(NULL != ret);
+    CHECK(COAP_STATUS_PARSER_BLOCKWISE_ACK == ret->coap_status);
     free(payload);
     sn_coap_parser_release_allocated_coap_msg_mem(handle, sn_coap_parser_stub.expectedHeader);
     sn_coap_protocol_clear_sent_blockwise_messages(handle);
@@ -1637,33 +1638,33 @@ void test_block2_receive(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t p
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_ACKNOWLEDGEMENT;
     sn_coap_parser_stub.expectedHeader->msg_id = 22;
 
-    list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    list = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = -1;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block2 = 0x08;
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
     sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_REQUEST_DELETE;
-    payload = (uint8_t*)malloc(17);
+    payload = (uint8_t *)malloc(17);
     sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
     sn_coap_parser_stub.expectedHeader->payload_len = 17;
     sn_coap_parser_stub.expectedHeader->token_len = 4;
-    sn_coap_parser_stub.expectedHeader->token_ptr = (uint8_t*)malloc(4);
+    sn_coap_parser_stub.expectedHeader->token_ptr = (uint8_t *)malloc(4);
     memset(sn_coap_parser_stub.expectedHeader->token_ptr, '1', 4);
 
     memset(&tmp_hdr, 0, sizeof(sn_coap_hdr_s));
-    dst_packet_data_ptr = (uint8_t*)malloc(5);
+    dst_packet_data_ptr = (uint8_t *)malloc(5);
     memset(dst_packet_data_ptr, '1', 5);
 
     retCounter = 20;
     sn_coap_builder_stub.expectedInt16 = 1;
-    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_len);
+    tmp_hdr.payload_ptr = (uint8_t *)malloc(buff_len);
 
     tmp_hdr.msg_id = 22;
     tmp_hdr.msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
     tmp_hdr.payload_len = buff_len;
     tmp_hdr.token_len = 4;
-    tmp_hdr.token_ptr = (uint8_t*)malloc(4);
+    tmp_hdr.token_ptr = (uint8_t *)malloc(4);
     memset(tmp_hdr.token_ptr, '1', 4);
     sn_coap_protocol_build(handle, addr, dst_packet_data_ptr, &tmp_hdr, NULL);
 
@@ -1676,7 +1677,7 @@ void test_block2_receive(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t p
 
     retCounter = 5;
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
-    CHECK( NULL == ret );
+    CHECK(NULL == ret);
     free(payload);
     sn_coap_protocol_clear_sent_blockwise_messages(handle);
     sn_coap_protocol_clear_retransmission_buffer(handle);
@@ -1687,33 +1688,33 @@ void test_block2_receive(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t p
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_ACKNOWLEDGEMENT;
     sn_coap_parser_stub.expectedHeader->msg_id = 23;
 
-    list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    list = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = -1;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block2 = 0x08;
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
     sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_REQUEST_DELETE;
-    payload = (uint8_t*)malloc(17);
+    payload = (uint8_t *)malloc(17);
     sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
     sn_coap_parser_stub.expectedHeader->payload_len = 17;
     sn_coap_parser_stub.expectedHeader->token_len = 4;
-    sn_coap_parser_stub.expectedHeader->token_ptr = (uint8_t*)malloc(4);
+    sn_coap_parser_stub.expectedHeader->token_ptr = (uint8_t *)malloc(4);
     memset(sn_coap_parser_stub.expectedHeader->token_ptr, '1', 4);
 
     memset(&tmp_hdr, 0, sizeof(sn_coap_hdr_s));
-    dst_packet_data_ptr = (uint8_t*)malloc(5);
+    dst_packet_data_ptr = (uint8_t *)malloc(5);
     memset(dst_packet_data_ptr, '1', 5);
 
     retCounter = 20;
     sn_coap_builder_stub.expectedInt16 = 1;
-    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_len);
+    tmp_hdr.payload_ptr = (uint8_t *)malloc(buff_len);
 
     tmp_hdr.msg_id = 23;
     tmp_hdr.msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
     tmp_hdr.payload_len = buff_len;
     tmp_hdr.token_len = 4;
-    tmp_hdr.token_ptr = (uint8_t*)malloc(4);
+    tmp_hdr.token_ptr = (uint8_t *)malloc(4);
     memset(tmp_hdr.token_ptr, '1', 4);
     sn_coap_protocol_build(handle, addr, dst_packet_data_ptr, &tmp_hdr, NULL);
 
@@ -1726,7 +1727,7 @@ void test_block2_receive(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t p
 
     retCounter = 3;
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
-    CHECK( NULL == ret );
+    CHECK(NULL == ret);
     free(payload);
     sn_coap_protocol_clear_retransmission_buffer(handle);
 }
@@ -1738,7 +1739,7 @@ void test_block2_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_ACKNOWLEDGEMENT;
 
-    sn_coap_options_list_s *list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    sn_coap_options_list_s *list = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = -1;
@@ -1746,12 +1747,12 @@ void test_block2_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
     sn_coap_parser_stub.expectedHeader->msg_id = 30;
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
     sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
-    uint8_t *payload = (uint8_t*)malloc(5);
+    uint8_t *payload = (uint8_t *)malloc(5);
     sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
     sn_coap_parser_stub.expectedHeader->payload_len = 5;
 
     sn_coap_hdr_s *ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
-    CHECK( NULL == ret );
+    CHECK(NULL == ret);
     free(payload);
 
     // sn_coap_handle_blockwise_message - (send block2) failed to allocate message!
@@ -1759,7 +1760,7 @@ void test_block2_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_ACKNOWLEDGEMENT;
 
-    list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    list = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = -1;
@@ -1767,21 +1768,21 @@ void test_block2_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
     sn_coap_parser_stub.expectedHeader->msg_id = 31;
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
     sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
-    payload = (uint8_t*)malloc(5);
+    payload = (uint8_t *)malloc(5);
     sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
     sn_coap_parser_stub.expectedHeader->payload_len = 5;
 
     sn_coap_hdr_s tmp_hdr;
     memset(&tmp_hdr, 0, sizeof(sn_coap_hdr_s));
 
-    uint8_t *dst_packet_data_ptr = (uint8_t*)malloc(5);
+    uint8_t *dst_packet_data_ptr = (uint8_t *)malloc(5);
     memset(dst_packet_data_ptr, '1', 5);
 
     retCounter = 20;
     sn_coap_builder_stub.expectedInt16 = 1;
     int buff_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
-    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_len);
-    tmp_hdr.options_list_ptr = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    tmp_hdr.payload_ptr = (uint8_t *)malloc(buff_len);
+    tmp_hdr.options_list_ptr = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(tmp_hdr.options_list_ptr, 0, sizeof(sn_coap_options_list_s));
     tmp_hdr.options_list_ptr->block2 = 1;
     tmp_hdr.msg_id = 31;
@@ -1794,7 +1795,7 @@ void test_block2_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
 
     retCounter = 0;
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
-    CHECK( NULL == ret );
+    CHECK(NULL == ret);
     free(payload);
     sn_coap_protocol_clear_sent_blockwise_messages(handle);
 
@@ -1803,7 +1804,7 @@ void test_block2_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_ACKNOWLEDGEMENT;
 
-    list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    list = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = -1;
@@ -1811,18 +1812,18 @@ void test_block2_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
     sn_coap_parser_stub.expectedHeader->msg_id = 32;
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
     sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
-    payload = (uint8_t*)malloc(5);
+    payload = (uint8_t *)malloc(5);
     sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
     sn_coap_parser_stub.expectedHeader->payload_len = 5;
 
     memset(&tmp_hdr, 0, sizeof(sn_coap_hdr_s));
-    dst_packet_data_ptr = (uint8_t*)malloc(5);
+    dst_packet_data_ptr = (uint8_t *)malloc(5);
     memset(dst_packet_data_ptr, '1', 5);
 
     retCounter = 20;
     sn_coap_builder_stub.expectedInt16 = 1;
-    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_len);
-    tmp_hdr.options_list_ptr = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    tmp_hdr.payload_ptr = (uint8_t *)malloc(buff_len);
+    tmp_hdr.options_list_ptr = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(tmp_hdr.options_list_ptr, 0, sizeof(sn_coap_options_list_s));
     tmp_hdr.options_list_ptr->block2 = 1;
     tmp_hdr.msg_id = 32;
@@ -1835,7 +1836,7 @@ void test_block2_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
 
     retCounter = 10;
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
-    CHECK( ret->coap_status == COAP_STATUS_PARSER_BLOCKWISE_MSG_RECEIVING );
+    CHECK(ret->coap_status == COAP_STATUS_PARSER_BLOCKWISE_MSG_RECEIVING);
     sn_coap_parser_release_allocated_coap_msg_mem(handle, sn_coap_parser_stub.expectedHeader);
     free(payload);
     sn_coap_protocol_clear_sent_blockwise_messages(handle);
@@ -1846,7 +1847,7 @@ void test_block2_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_ACKNOWLEDGEMENT;
 
-    list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    list = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = -1;
@@ -1854,18 +1855,18 @@ void test_block2_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
     sn_coap_parser_stub.expectedHeader->msg_id = 32;
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
     sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
-    payload = (uint8_t*)malloc(5);
+    payload = (uint8_t *)malloc(5);
     sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
     sn_coap_parser_stub.expectedHeader->payload_len = 5;
 
     memset(&tmp_hdr, 0, sizeof(sn_coap_hdr_s));
-    dst_packet_data_ptr = (uint8_t*)malloc(5);
+    dst_packet_data_ptr = (uint8_t *)malloc(5);
     memset(dst_packet_data_ptr, '1', 5);
 
     retCounter = 20;
     sn_coap_builder_stub.expectedInt16 = 1;
-    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_len);
-    tmp_hdr.options_list_ptr = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    tmp_hdr.payload_ptr = (uint8_t *)malloc(buff_len);
+    tmp_hdr.options_list_ptr = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(tmp_hdr.options_list_ptr, 0, sizeof(sn_coap_options_list_s));
     tmp_hdr.options_list_ptr->block2 = 1;
     tmp_hdr.msg_id = 32;
@@ -1878,7 +1879,7 @@ void test_block2_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
 
     retCounter = 10;
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
-    CHECK( ret->coap_status == COAP_STATUS_PARSER_DUPLICATED_MSG );
+    CHECK(ret->coap_status == COAP_STATUS_PARSER_DUPLICATED_MSG);
     sn_coap_parser_release_allocated_coap_msg_mem(handle, sn_coap_parser_stub.expectedHeader);
     free(payload);
     sn_coap_protocol_clear_sent_blockwise_messages(handle);
@@ -1889,7 +1890,7 @@ void test_block2_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_ACKNOWLEDGEMENT;
 
-    list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    list = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = -1;
@@ -1897,26 +1898,26 @@ void test_block2_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
     sn_coap_parser_stub.expectedHeader->msg_id = 33;
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
     sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
-    payload = (uint8_t*)malloc(5);
+    payload = (uint8_t *)malloc(5);
     sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
     sn_coap_parser_stub.expectedHeader->payload_len = 5;
 
     memset(&tmp_hdr, 0, sizeof(sn_coap_hdr_s));
-    dst_packet_data_ptr = (uint8_t*)malloc(5);
+    dst_packet_data_ptr = (uint8_t *)malloc(5);
     memset(dst_packet_data_ptr, '1', 5);
 
     retCounter = 20;
     sn_coap_builder_stub.expectedInt16 = 1;
-    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_len);
-    tmp_hdr.options_list_ptr = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    tmp_hdr.payload_ptr = (uint8_t *)malloc(buff_len);
+    tmp_hdr.options_list_ptr = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(tmp_hdr.options_list_ptr, 0, sizeof(sn_coap_options_list_s));
     tmp_hdr.options_list_ptr->block2 = 1;
     tmp_hdr.msg_id = 33;
     tmp_hdr.payload_len = buff_len;
 
-    tmp_hdr.uri_path_ptr = (uint8_t*)malloc(buff_len);
+    tmp_hdr.uri_path_ptr = (uint8_t *)malloc(buff_len);
     tmp_hdr.uri_path_len = buff_len;
-    tmp_hdr.token_ptr = (uint8_t*)malloc(buff_len);
+    tmp_hdr.token_ptr = (uint8_t *)malloc(buff_len);
     tmp_hdr.token_len = buff_len;
 
     sn_coap_protocol_build(handle, addr, dst_packet_data_ptr, &tmp_hdr, NULL);
@@ -1929,7 +1930,7 @@ void test_block2_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
 
     retCounter = 10;
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
-    CHECK( ret->coap_status == COAP_STATUS_PARSER_BLOCKWISE_MSG_RECEIVING );
+    CHECK(ret->coap_status == COAP_STATUS_PARSER_BLOCKWISE_MSG_RECEIVING);
     sn_coap_parser_release_allocated_coap_msg_mem(handle, sn_coap_parser_stub.expectedHeader);
     free(payload);
     sn_coap_protocol_clear_sent_blockwise_messages(handle);
@@ -1940,7 +1941,7 @@ void test_block2_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_ACKNOWLEDGEMENT;
 
-    list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    list = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = -1;
@@ -1948,26 +1949,26 @@ void test_block2_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
     sn_coap_parser_stub.expectedHeader->msg_id = 34;
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
     sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
-    payload = (uint8_t*)malloc(5);
+    payload = (uint8_t *)malloc(5);
     sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
     sn_coap_parser_stub.expectedHeader->payload_len = 5;
 
     memset(&tmp_hdr, 0, sizeof(sn_coap_hdr_s));
-    dst_packet_data_ptr = (uint8_t*)malloc(5);
+    dst_packet_data_ptr = (uint8_t *)malloc(5);
     memset(dst_packet_data_ptr, '1', 5);
 
     retCounter = 20;
     sn_coap_builder_stub.expectedInt16 = 1;
-    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_len);
-    tmp_hdr.options_list_ptr = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    tmp_hdr.payload_ptr = (uint8_t *)malloc(buff_len);
+    tmp_hdr.options_list_ptr = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(tmp_hdr.options_list_ptr, 0, sizeof(sn_coap_options_list_s));
     tmp_hdr.options_list_ptr->block2 = 1;
     tmp_hdr.msg_id = 34;
     tmp_hdr.payload_len = buff_len;
 
-    tmp_hdr.uri_path_ptr = (uint8_t*)malloc(buff_len);
+    tmp_hdr.uri_path_ptr = (uint8_t *)malloc(buff_len);
     tmp_hdr.uri_path_len = buff_len;
-    tmp_hdr.token_ptr = (uint8_t*)malloc(buff_len);
+    tmp_hdr.token_ptr = (uint8_t *)malloc(buff_len);
     tmp_hdr.token_len = buff_len;
 
     sn_coap_protocol_build(handle, addr, dst_packet_data_ptr, &tmp_hdr, NULL);
@@ -1980,7 +1981,7 @@ void test_block2_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
 
     retCounter = 5;
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
-    CHECK( ret == NULL );
+    CHECK(ret == NULL);
     free(payload);
     sn_coap_protocol_clear_sent_blockwise_messages(handle);
     sn_coap_protocol_clear_retransmission_buffer(handle);
@@ -1990,7 +1991,7 @@ void test_block2_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_ACKNOWLEDGEMENT;
 
-    list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    list = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = -1;
@@ -1998,26 +1999,26 @@ void test_block2_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
     sn_coap_parser_stub.expectedHeader->msg_id = 35;
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
     sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
-    payload = (uint8_t*)malloc(5);
+    payload = (uint8_t *)malloc(5);
     sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
     sn_coap_parser_stub.expectedHeader->payload_len = 5;
 
     memset(&tmp_hdr, 0, sizeof(sn_coap_hdr_s));
-    dst_packet_data_ptr = (uint8_t*)malloc(5);
+    dst_packet_data_ptr = (uint8_t *)malloc(5);
     memset(dst_packet_data_ptr, '1', 5);
 
     retCounter = 20;
     sn_coap_builder_stub.expectedInt16 = 1;
-    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_len);
-    tmp_hdr.options_list_ptr = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    tmp_hdr.payload_ptr = (uint8_t *)malloc(buff_len);
+    tmp_hdr.options_list_ptr = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(tmp_hdr.options_list_ptr, 0, sizeof(sn_coap_options_list_s));
     tmp_hdr.options_list_ptr->block2 = 1;
     tmp_hdr.msg_id = 35;
     tmp_hdr.payload_len = buff_len;
 
-    tmp_hdr.uri_path_ptr = (uint8_t*)malloc(buff_len);
+    tmp_hdr.uri_path_ptr = (uint8_t *)malloc(buff_len);
     tmp_hdr.uri_path_len = buff_len;
-    tmp_hdr.token_ptr = (uint8_t*)malloc(buff_len);
+    tmp_hdr.token_ptr = (uint8_t *)malloc(buff_len);
     tmp_hdr.token_len = buff_len;
 
     sn_coap_protocol_build(handle, addr, dst_packet_data_ptr, &tmp_hdr, NULL);
@@ -2030,7 +2031,7 @@ void test_block2_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
 
     retCounter = 6;
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
-    CHECK( ret == NULL );
+    CHECK(ret == NULL);
     free(payload);
     sn_coap_protocol_clear_sent_blockwise_messages(handle);
     sn_coap_protocol_clear_retransmission_buffer(handle);
@@ -2040,7 +2041,7 @@ void test_block2_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_ACKNOWLEDGEMENT;
 
-    list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    list = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = -1;
@@ -2048,26 +2049,26 @@ void test_block2_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
     sn_coap_parser_stub.expectedHeader->msg_id = 36;
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
     sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
-    payload = (uint8_t*)malloc(5);
+    payload = (uint8_t *)malloc(5);
     sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
     sn_coap_parser_stub.expectedHeader->payload_len = 5;
 
     memset(&tmp_hdr, 0, sizeof(sn_coap_hdr_s));
-    dst_packet_data_ptr = (uint8_t*)malloc(5);
+    dst_packet_data_ptr = (uint8_t *)malloc(5);
     memset(dst_packet_data_ptr, '1', 5);
 
     retCounter = 20;
     sn_coap_builder_stub.expectedInt16 = 1;
-    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_len);
-    tmp_hdr.options_list_ptr = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    tmp_hdr.payload_ptr = (uint8_t *)malloc(buff_len);
+    tmp_hdr.options_list_ptr = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(tmp_hdr.options_list_ptr, 0, sizeof(sn_coap_options_list_s));
     tmp_hdr.options_list_ptr->block2 = 1;
     tmp_hdr.msg_id = 36;
     tmp_hdr.payload_len = buff_len;
 
-    tmp_hdr.uri_path_ptr = (uint8_t*)malloc(buff_len);
+    tmp_hdr.uri_path_ptr = (uint8_t *)malloc(buff_len);
     tmp_hdr.uri_path_len = buff_len;
-    tmp_hdr.token_ptr = (uint8_t*)malloc(buff_len);
+    tmp_hdr.token_ptr = (uint8_t *)malloc(buff_len);
     tmp_hdr.token_len = buff_len;
 
     sn_coap_protocol_build(handle, addr, dst_packet_data_ptr, &tmp_hdr, NULL);
@@ -2080,7 +2081,7 @@ void test_block2_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
 
     retCounter = 7;
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
-    CHECK( ret == NULL );
+    CHECK(ret == NULL);
     free(payload);
     sn_coap_protocol_clear_sent_blockwise_messages(handle);
     sn_coap_protocol_clear_retransmission_buffer(handle);
@@ -2090,7 +2091,7 @@ void test_block2_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_ACKNOWLEDGEMENT;
 
-    list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    list = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = -1;
@@ -2098,26 +2099,26 @@ void test_block2_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
     sn_coap_parser_stub.expectedHeader->msg_id = 37;
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
     sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
-    payload = (uint8_t*)malloc(5);
+    payload = (uint8_t *)malloc(5);
     sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
     sn_coap_parser_stub.expectedHeader->payload_len = 5;
 
     memset(&tmp_hdr, 0, sizeof(sn_coap_hdr_s));
-    dst_packet_data_ptr = (uint8_t*)malloc(5);
+    dst_packet_data_ptr = (uint8_t *)malloc(5);
     memset(dst_packet_data_ptr, '1', 5);
 
     retCounter = 20;
     sn_coap_builder_stub.expectedInt16 = 1;
-    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_len);
-    tmp_hdr.options_list_ptr = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    tmp_hdr.payload_ptr = (uint8_t *)malloc(buff_len);
+    tmp_hdr.options_list_ptr = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(tmp_hdr.options_list_ptr, 0, sizeof(sn_coap_options_list_s));
     tmp_hdr.options_list_ptr->block2 = 1;
     tmp_hdr.msg_id = 37;
     tmp_hdr.payload_len = buff_len;
 
-    tmp_hdr.uri_path_ptr = (uint8_t*)malloc(buff_len);
+    tmp_hdr.uri_path_ptr = (uint8_t *)malloc(buff_len);
     tmp_hdr.uri_path_len = buff_len;
-    tmp_hdr.token_ptr = (uint8_t*)malloc(buff_len);
+    tmp_hdr.token_ptr = (uint8_t *)malloc(buff_len);
     tmp_hdr.token_len = buff_len;
 
     sn_coap_protocol_build(handle, addr, dst_packet_data_ptr, &tmp_hdr, NULL);
@@ -2130,7 +2131,7 @@ void test_block2_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
 
     retCounter = 8;
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
-    CHECK( ret == NULL );
+    CHECK(ret == NULL);
     free(payload);
     sn_coap_protocol_clear_sent_blockwise_messages(handle);
     sn_coap_protocol_clear_retransmission_buffer(handle);
@@ -2140,7 +2141,7 @@ void test_block2_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_ACKNOWLEDGEMENT;
 
-    list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    list = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = -1;
@@ -2148,26 +2149,26 @@ void test_block2_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
     sn_coap_parser_stub.expectedHeader->msg_id = 38;
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
     sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
-    payload = (uint8_t*)malloc(5);
+    payload = (uint8_t *)malloc(5);
     sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
     sn_coap_parser_stub.expectedHeader->payload_len = 5;
 
     memset(&tmp_hdr, 0, sizeof(sn_coap_hdr_s));
-    dst_packet_data_ptr = (uint8_t*)malloc(5);
+    dst_packet_data_ptr = (uint8_t *)malloc(5);
     memset(dst_packet_data_ptr, '1', 5);
 
     retCounter = 20;
 
-    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_len);
-    tmp_hdr.options_list_ptr = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    tmp_hdr.payload_ptr = (uint8_t *)malloc(buff_len);
+    tmp_hdr.options_list_ptr = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(tmp_hdr.options_list_ptr, 0, sizeof(sn_coap_options_list_s));
     tmp_hdr.options_list_ptr->block2 = 1;
     tmp_hdr.msg_id = 38;
     tmp_hdr.payload_len = buff_len;
 
-    tmp_hdr.uri_path_ptr = (uint8_t*)malloc(buff_len);
+    tmp_hdr.uri_path_ptr = (uint8_t *)malloc(buff_len);
     tmp_hdr.uri_path_len = buff_len;
-    tmp_hdr.token_ptr = (uint8_t*)malloc(buff_len);
+    tmp_hdr.token_ptr = (uint8_t *)malloc(buff_len);
     tmp_hdr.token_len = buff_len;
 
     sn_coap_protocol_build(handle, addr, dst_packet_data_ptr, &tmp_hdr, NULL);
@@ -2181,7 +2182,7 @@ void test_block2_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
     retCounter = 10;
     sn_coap_builder_stub.expectedInt16 = -1;
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
-    CHECK( ret == NULL );
+    CHECK(ret == NULL);
     free(payload);
     sn_coap_protocol_clear_sent_blockwise_messages(handle);
     sn_coap_protocol_clear_retransmission_buffer(handle);
@@ -2191,7 +2192,7 @@ void test_block2_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_ACKNOWLEDGEMENT;
 
-    list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    list = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = -1;
@@ -2199,14 +2200,14 @@ void test_block2_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
     sn_coap_parser_stub.expectedHeader->msg_id = 41;
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
     sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
-    payload = (uint8_t*)malloc(5);
+    payload = (uint8_t *)malloc(5);
     sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
     sn_coap_parser_stub.expectedHeader->payload_len = 5;
 
     retCounter = 10;
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
-    CHECK( NULL != ret );
-    CHECK( ret->coap_status == COAP_STATUS_PARSER_BLOCKWISE_MSG_RECEIVED );
+    CHECK(NULL != ret);
+    CHECK(ret->coap_status == COAP_STATUS_PARSER_BLOCKWISE_MSG_RECEIVED);
     free(payload);
 #if !SN_COAP_REDUCE_BLOCKWISE_HEAP_FOOTPRINT
     free(sn_coap_parser_stub.expectedHeader->payload_ptr);
@@ -2223,15 +2224,15 @@ void test_block2_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
     sn_coap_parser_stub.expectedHeader->msg_id = 100;
 
     memset(&tmp_hdr, 0, sizeof(sn_coap_hdr_s));
-    dst_packet_data_ptr = (uint8_t*)malloc(5);
+    dst_packet_data_ptr = (uint8_t *)malloc(5);
     memset(dst_packet_data_ptr, '1', 5);
-    dst_packet_data_ptr[2]=0;
-    dst_packet_data_ptr[3]=18;
+    dst_packet_data_ptr[2] = 0;
+    dst_packet_data_ptr[3] = 18;
 
     retCounter = 20;
     sn_coap_builder_stub.expectedInt16 = 5;
     buff_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
-    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_len);
+    tmp_hdr.payload_ptr = (uint8_t *)malloc(buff_len);
     tmp_hdr.msg_id = 100;
     tmp_hdr.msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
     tmp_hdr.payload_len = buff_len;
@@ -2242,7 +2243,7 @@ void test_block2_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
     free(dst_packet_data_ptr);
 
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
-    CHECK( ret != NULL );
+    CHECK(ret != NULL);
     sn_coap_parser_release_allocated_coap_msg_mem(handle, ret);
 
     // Do not clean stored blockwise message when empty ack is received - remove from the list
@@ -2254,19 +2255,19 @@ void test_block2_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
 
     memset(&tmp_hdr, 0, sizeof(sn_coap_hdr_s));
 
-    dst_packet_data_ptr = (uint8_t*)malloc(5);
+    dst_packet_data_ptr = (uint8_t *)malloc(5);
     memset(dst_packet_data_ptr, '1', 5);
-    dst_packet_data_ptr[2]=0;
-    dst_packet_data_ptr[3]=185;
+    dst_packet_data_ptr[2] = 0;
+    dst_packet_data_ptr[3] = 185;
 
     retCounter = 20;
     sn_coap_builder_stub.expectedInt16 = 5;
     buff_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
-    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_len);
+    tmp_hdr.payload_ptr = (uint8_t *)malloc(buff_len);
     tmp_hdr.msg_id = 101;
     tmp_hdr.msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
     tmp_hdr.payload_len = buff_len;
-    tmp_hdr.options_list_ptr = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    tmp_hdr.options_list_ptr = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(tmp_hdr.options_list_ptr, 0, sizeof(sn_coap_options_list_s));
     tmp_hdr.options_list_ptr->observe = 1;
     sn_coap_protocol_build(handle, addr, dst_packet_data_ptr, &tmp_hdr, NULL);
@@ -2276,7 +2277,7 @@ void test_block2_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
     free(dst_packet_data_ptr);
 
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
-    CHECK( ret != NULL );
+    CHECK(ret != NULL);
     sn_coap_parser_release_allocated_coap_msg_mem(handle, ret);
 
     // Do not clean stored blockwise message when empty ack is received - remove from the list
@@ -2288,19 +2289,19 @@ void test_block2_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
 
     memset(&tmp_hdr, 0, sizeof(sn_coap_hdr_s));
 
-    dst_packet_data_ptr = (uint8_t*)malloc(5);
+    dst_packet_data_ptr = (uint8_t *)malloc(5);
     memset(dst_packet_data_ptr, '1', 5);
-    dst_packet_data_ptr[2]=0;
-    dst_packet_data_ptr[3]=185;
+    dst_packet_data_ptr[2] = 0;
+    dst_packet_data_ptr[3] = 185;
 
     retCounter = 20;
     sn_coap_builder_stub.expectedInt16 = 5;
     buff_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
-    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_len);
+    tmp_hdr.payload_ptr = (uint8_t *)malloc(buff_len);
     tmp_hdr.msg_id = 101;
     tmp_hdr.msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
     tmp_hdr.payload_len = buff_len;
-    tmp_hdr.options_list_ptr = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    tmp_hdr.options_list_ptr = (sn_coap_options_list_s *)malloc(sizeof(sn_coap_options_list_s));
     memset(tmp_hdr.options_list_ptr, 0, sizeof(sn_coap_options_list_s));
     tmp_hdr.options_list_ptr->observe = 1;
     sn_coap_protocol_build(handle, addr, dst_packet_data_ptr, &tmp_hdr, NULL);
@@ -2310,6 +2311,6 @@ void test_block2_send(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t pack
     free(dst_packet_data_ptr);
 
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
-    CHECK( ret != NULL );
+    CHECK(ret != NULL);
     sn_coap_parser_release_allocated_coap_msg_mem(handle, ret);
 }


### PR DESCRIPTION
This will revert commit a809a60

Can happen that block1 response with same message id is received again even when block-wise transfer has gone further.
Changing COAP_STATUS_OK to COAP_STATUS_PARSER_BLOCKWISE_ACK make sure that caller does not process message again.

This will fix error: IOTCLT-4864 - Client <-> Server message id lists out-of-sync causing misidentification of coap duplication

<!--

For more information on the requirements for pull requests, please see [the CONTRIBUTING.md](CONTRIBUTING.md).

-->

[x I confirm this contribution is my own and I agree to license it with Apache 2.0.
[x I confirm the moderators may change the PR before merging it in.

### Summary of changes <!-- Required -->

<!--
    Please provide the following information:

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed, add references to issues if this is a fix.

    Avoid too large commits. Each commit should be an atomic, independent change.

    Write good, descriptive Git commit messages.

-->

